### PR TITLE
[ARV-9] 공통 Response, Exception Handler 세팅 

### DIFF
--- a/src/main/java/com/kwanse/allreva/common/dto/Response.java
+++ b/src/main/java/com/kwanse/allreva/common/dto/Response.java
@@ -7,9 +7,6 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-import static com.kwanse.allreva.common.dto.ResponseConst.SUCCESS;
-import static com.kwanse.allreva.common.dto.ResponseConst.SUCCESS_MESSAGE;
-
 @Getter
 @AllArgsConstructor
 @JsonPropertyOrder({"timeStamp", "code", "message", "result"})
@@ -26,11 +23,11 @@ public class Response<T> {
     }
 
     public static <T> Response<T> onSuccess(T result) {
-        return new Response<>(SUCCESS, SUCCESS_MESSAGE, result);
+        return new Response<>("SUCCESS", "요청에 성공하였습니다.", result);
     }
 
     public static <T> Response<T> onSuccess() {
-        return new Response<>(SUCCESS, SUCCESS_MESSAGE);
+        return new Response<>("SUCCESS", "요청에 성공하였습니다.");
     }
 
     public static <T> Response<T> onFailure(String errorCode, String message) {

--- a/src/main/java/com/kwanse/allreva/common/dto/Response.java
+++ b/src/main/java/com/kwanse/allreva/common/dto/Response.java
@@ -1,0 +1,39 @@
+package com.kwanse.allreva.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+import static com.kwanse.allreva.common.dto.ResponseConst.SUCCESS;
+import static com.kwanse.allreva.common.dto.ResponseConst.SUCCESS_MESSAGE;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"timeStamp", "code", "message", "result"})
+public class Response<T> {
+    private final LocalDateTime timeStamp = LocalDateTime.now();
+    private String code;
+    private String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+    public Response(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public static <T> Response<T> onSuccess(T result) {
+        return new Response<>(SUCCESS, SUCCESS_MESSAGE, result);
+    }
+
+    public static <T> Response<T> onSuccess() {
+        return new Response<>(SUCCESS, SUCCESS_MESSAGE);
+    }
+
+    public static <T> Response<T> onFailure(String errorCode, String message) {
+        return new Response<>(errorCode, message);
+    }
+}

--- a/src/main/java/com/kwanse/allreva/common/dto/Response.java
+++ b/src/main/java/com/kwanse/allreva/common/dto/Response.java
@@ -12,8 +12,8 @@ import java.time.LocalDateTime;
 @JsonPropertyOrder({"timeStamp", "code", "message", "result"})
 public class Response<T> {
     private final LocalDateTime timeStamp = LocalDateTime.now();
-    private String code;
-    private String message;
+    private final String code;
+    private final String message;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private T result;
 

--- a/src/main/java/com/kwanse/allreva/common/dto/ResponseConst.java
+++ b/src/main/java/com/kwanse/allreva/common/dto/ResponseConst.java
@@ -1,0 +1,6 @@
+package com.kwanse.allreva.common.dto;
+
+public final class ResponseConst {
+    public static final String SUCCESS = "SUCCESS";
+    public static final String SUCCESS_MESSAGE = "요청에 성공하였습니다.";
+}

--- a/src/main/java/com/kwanse/allreva/common/dto/ResponseConst.java
+++ b/src/main/java/com/kwanse/allreva/common/dto/ResponseConst.java
@@ -1,6 +1,0 @@
-package com.kwanse.allreva.common.dto;
-
-public final class ResponseConst {
-    public static final String SUCCESS = "SUCCESS";
-    public static final String SUCCESS_MESSAGE = "요청에 성공하였습니다.";
-}

--- a/src/main/java/com/kwanse/allreva/common/exception/CustomControllerAdvice.java
+++ b/src/main/java/com/kwanse/allreva/common/exception/CustomControllerAdvice.java
@@ -20,8 +20,8 @@ public class CustomControllerAdvice {
                                 e.getErrorCode().message()
                         )
                 );
-
     }
+
     @ExceptionHandler(value = Exception.class)
     public ResponseEntity<?> handleException(Exception e) {
         log.error("error: {}", e.getMessage(), e);

--- a/src/main/java/com/kwanse/allreva/common/exception/CustomControllerAdvice.java
+++ b/src/main/java/com/kwanse/allreva/common/exception/CustomControllerAdvice.java
@@ -1,0 +1,36 @@
+package com.kwanse.allreva.common.exception;
+
+import com.kwanse.allreva.common.dto.Response;
+import com.kwanse.allreva.common.exception.code.GlobalErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class CustomControllerAdvice {
+
+    @ExceptionHandler(value = CustomException.class)
+    public ResponseEntity<?> handleCustomException(CustomException e) {
+        return ResponseEntity.status(e.getErrorCode().status())
+                .body(
+                        Response.onFailure(
+                                e.getErrorCode().code(),
+                                e.getErrorCode().message()
+                        )
+                );
+
+    }
+    @ExceptionHandler(value = Exception.class)
+    public ResponseEntity<?> handleException(Exception e) {
+        log.error("error: {}", e.getMessage(), e);
+        return ResponseEntity.status(GlobalErrorCode.SERVER_ERROR.getErrorCode().status())
+                .body(
+                        Response.onFailure(
+                                GlobalErrorCode.SERVER_ERROR.getErrorCode().code(),
+                                GlobalErrorCode.SERVER_ERROR.getErrorCode().message()
+                               )
+                );
+    }
+}

--- a/src/main/java/com/kwanse/allreva/common/exception/CustomException.java
+++ b/src/main/java/com/kwanse/allreva/common/exception/CustomException.java
@@ -1,0 +1,16 @@
+package com.kwanse.allreva.common.exception;
+
+import com.kwanse.allreva.common.exception.code.ErrorCode;
+import com.kwanse.allreva.common.exception.code.ErrorCodeInterface;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException {
+    private final ErrorCodeInterface errorCode;
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode.getErrorCode();
+    }
+}

--- a/src/main/java/com/kwanse/allreva/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/kwanse/allreva/common/exception/code/ErrorCode.java
@@ -1,0 +1,7 @@
+package com.kwanse.allreva.common.exception.code;
+
+public record ErrorCode(Integer status, String code, String message) {
+    public static ErrorCode of(Integer status, String code, String message) {
+        return new ErrorCode(status, code, message);
+    }
+}

--- a/src/main/java/com/kwanse/allreva/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/kwanse/allreva/common/exception/code/ErrorCode.java
@@ -1,7 +1,7 @@
 package com.kwanse.allreva.common.exception.code;
 
 public record ErrorCode(Integer status, String code, String message) {
-    public static ErrorCode of(Integer status, String code, String message) {
+    public static ErrorCode of(final Integer status, final String code, final String message) {
         return new ErrorCode(status, code, message);
     }
 }

--- a/src/main/java/com/kwanse/allreva/common/exception/code/ErrorCodeInterface.java
+++ b/src/main/java/com/kwanse/allreva/common/exception/code/ErrorCodeInterface.java
@@ -1,0 +1,5 @@
+package com.kwanse.allreva.common.exception.code;
+
+public interface ErrorCodeInterface {
+    ErrorCode getErrorCode();
+}

--- a/src/main/java/com/kwanse/allreva/common/exception/code/GlobalErrorCode.java
+++ b/src/main/java/com/kwanse/allreva/common/exception/code/GlobalErrorCode.java
@@ -1,0 +1,26 @@
+package com.kwanse.allreva.common.exception.code;
+
+import lombok.RequiredArgsConstructor;
+
+import static org.springframework.http.HttpStatus.*;
+
+
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCodeInterface {
+    BAD_REQUEST_ERROR(BAD_REQUEST.value(), BAD_REQUEST.name(), "잘못된 요청입니다."),
+    NOT_SUPPORTED_URI_ERROR(NOT_FOUND.value(), NOT_FOUND.name(), "올바르지 않은 URI입니다."),
+    NOT_SUPPORTED_METHOD_ERROR(METHOD_NOT_ALLOWED.value(), METHOD_NOT_ALLOWED.name(), "지원하지 않는 Method입니다."),
+    NOT_SUPPORTED_MEDIA_TYPE_ERROR(UNSUPPORTED_MEDIA_TYPE.value(), UNSUPPORTED_MEDIA_TYPE.name(), "지원하지 않는 Media type입니다."),
+    SERVER_ERROR(INTERNAL_SERVER_ERROR.value(), INTERNAL_SERVER_ERROR.name(), "서버 에러, 관리자에게 문의해주세요."),
+    ACCESS_DENIED(FORBIDDEN.value(), FORBIDDEN.name(), "올바르지 않은 권한입니다."),
+    ;
+
+    private final Integer status;
+    private final String errorCode;
+    private final String message;
+
+    @Override
+    public ErrorCode getErrorCode() {
+        return ErrorCode.of(status, errorCode, message);
+    }
+}

--- a/src/main/java/com/kwanse/allreva/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/kwanse/allreva/member/exception/MemberErrorCode.java
@@ -1,0 +1,21 @@
+package com.kwanse.allreva.member.exception;
+
+import com.kwanse.allreva.common.exception.code.ErrorCode;
+import com.kwanse.allreva.common.exception.code.ErrorCodeInterface;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ErrorCodeInterface {
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "MEMBER_NOT_FOUND", "존재하지 않는 회원입니다." )
+    ;
+
+    private final Integer status;
+    private final String errorCode;
+    private final String message;
+
+    @Override
+    public ErrorCode getErrorCode() {
+        return ErrorCode.of(status, errorCode, message);
+    }
+}

--- a/src/main/java/com/kwanse/allreva/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/kwanse/allreva/member/exception/MemberNotFoundException.java
@@ -1,0 +1,9 @@
+package com.kwanse.allreva.member.exception;
+
+import com.kwanse.allreva.common.exception.CustomException;
+
+public class MemberNotFoundException extends CustomException {
+    public MemberNotFoundException() {
+        super(MemberErrorCode.MEMBER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/kwanse/allreva/member/ui/MemberController.java
+++ b/src/main/java/com/kwanse/allreva/member/ui/MemberController.java
@@ -1,7 +1,9 @@
 package com.kwanse.allreva.member.ui;
 
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("api/v1/members")
 public class MemberController {
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=allreva


### PR DESCRIPTION
### 연결된 issue 🌟
ex) 연결된 issue를 자동으로 닫기 위해 # 다음 이슈 넘버를 입력해주세요. ex) #2 
<br>
- closed #10 

### 구현 내용 📢
공통 응답과 예외 처리를 설계했습니다.
기본 응답은 timestamp, code, message, data로 이루어져있습니다. result는 body가 있으면 넘겨줍니다.

```
{
  "timeStamp": "2024-11-17T20:54:38.569189",
  "code": "SUCCESS",
  "message": "요청에 성공하였습니다.",
  "result" : 1
}
```
예외 응답의 경우, result는 존재하지 않습니다.
```
{
  "timeStamp": "2024-11-17T20:54:38.569189",
  "code": "MEMBER_NOT_FOUND",
  "message": "존재하지 않는 회원입니다."
}
```
예시 용으로 MemberErrorCode와 MemberNotFoundException을 정의해두었습니다. 
도메인별로 ErrorCode를 따로 적어 사용하고, Exception도 정의해서 사용하면  다음과 같이 코드상에서 더 직관적이고 간결해 보일 것 같아 그냥 따로 정의하도록 하였습니다!

```
if(check) {
         throw new MemberNotFoundException();
}
```
다른 의견 있으면 남겨주세요.

### 리뷰 포인트 📌
아직 구조가 헷갈려서 패키지를 제대로 위치해둔건지 잘 모르겠는데 지금 구조 괜찮은지 의견 남겨주세요!