### PR TITLE
[ARV-53] JwtAuthenticationFilter 모든 요청 허용하도록 수정

### DIFF
--- a/src/main/java/com/backend/allreva/auth/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/backend/allreva/auth/exception/CustomAccessDeniedHandler.java
@@ -33,10 +33,9 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
             AccessDeniedException accessDeniedException) throws IOException, ServletException {
         Exception exception = (Exception) request.getAttribute("jakarta.servlet.error.exception");
         if (exception != null) {
-            log.info("권한 없음 예외 발생: {}", exception);
+            log.info("Access denied: {}", exception.getMessage());
             resolver.resolveException(request, response, null, exception);
         } else {
-            log.info("권한 없음 예외 발생: {}", accessDeniedException);
             resolver.resolveException(request, response, null, accessDeniedException);
         }
     }

--- a/src/main/java/com/backend/allreva/auth/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/backend/allreva/auth/exception/CustomAuthenticationEntryPoint.java
@@ -35,7 +35,10 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     public void commence(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException authException) throws IOException, ServletException {
         Exception jwtException = (Exception) request.getAttribute("jakarta.servlet.error.exception");
-        log.info("JWT 인증 예외 발생: {}", jwtException);
-        resolver.resolveException(request, response, null, jwtException);
+        if (jwtException == null) {
+            resolver.resolveException(request, response, null, authException);
+        } else {
+            resolver.resolveException(request, response, null, jwtException);
+        }
     }
 }

--- a/src/main/java/com/backend/allreva/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/backend/allreva/auth/filter/JwtAuthenticationFilter.java
@@ -1,44 +1,27 @@
 package com.backend.allreva.auth.filter;
 
+import com.backend.allreva.auth.util.JwtParser;
+import com.backend.allreva.auth.util.JwtValidator;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.List;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import com.backend.allreva.auth.exception.code.JwtTokenNotFoundException;
-import com.backend.allreva.auth.util.JwtParser;
-import com.backend.allreva.auth.util.JwtValidator;
-
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
-
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-
-    private static final List<RequestMatcher> EXCLUDED_URL_MATCHERS = List.of(
-            new AntPathRequestMatcher("/h2-console/**"),
-
-            new AntPathRequestMatcher("/swagger-ui/**"),
-            new AntPathRequestMatcher("/v3/api-docs/**"),
-            new AntPathRequestMatcher("/swagger-resources/**"),
-
-            // OAuth2 관련 URL
-            new AntPathRequestMatcher("/api/v1/oauth2/login/**"),
-            new AntPathRequestMatcher("/login/oauth2/**"),
-            new AntPathRequestMatcher("/favicon.*"));
 
     private final JwtParser jwtParser;
     private final JwtValidator jwtValidator;
@@ -53,17 +36,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             @NonNull final HttpServletResponse response,
             @NonNull final FilterChain filterChain
     ) throws ServletException, IOException {
-        // JWT 인가 과정 필요없는 URL 제외
-        if (isExcluded(request)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        // request로부터 token 받기
+        // token이 없다면 ANONYMOUS 로그인
         String refreshToken = jwtParser.getRefreshToken(request);
         String accessToken = jwtParser.getAccessToken(request);
         if (accessToken == null && refreshToken == null) {
-            throw new JwtTokenNotFoundException();
+            log.debug("GUEST login! {}", request.getRequestURI());
+            filterChain.doFilter(request, response);
+            return;
         }
 
         // token 검증 수행
@@ -82,11 +61,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         setAuthenication(memberId, request);
 
         filterChain.doFilter(request, response);
-    }
-
-    private boolean isExcluded(final HttpServletRequest request) {
-        return EXCLUDED_URL_MATCHERS.stream()
-                .anyMatch(matcher -> matcher.matches(request));
     }
 
     private void setAuthenication(final String email, final HttpServletRequest request) {

--- a/src/main/java/com/backend/allreva/auth/util/JwtValidator.java
+++ b/src/main/java/com/backend/allreva/auth/util/JwtValidator.java
@@ -2,6 +2,7 @@ package com.backend.allreva.auth.util;
 
 import javax.crypto.SecretKey;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +17,7 @@ import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 
+@Slf4j
 @Component
 public class JwtValidator {
 
@@ -32,10 +34,13 @@ public class JwtValidator {
                     .build()
                     .parse(token);
         } catch (MalformedJwtException e) {
+            log.error("Invalid JWT token: {}", e.getMessage());
             throw new InvalidJwtTokenException();
         } catch (SignatureException e) {
+            log.error("Invalid JWT token signature: {}", e.getMessage());
             throw new InvalidJwtSignatureException();
         } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token: {}", e.getMessage());
             throw new ExpiredJwtTokenException();
         }
     }

--- a/src/main/java/com/backend/allreva/common/exception/CustomControllerAdvice.java
+++ b/src/main/java/com/backend/allreva/common/exception/CustomControllerAdvice.java
@@ -13,6 +13,7 @@ public class CustomControllerAdvice {
 
     @ExceptionHandler(value = CustomException.class)
     public ResponseEntity<?> handleCustomException(CustomException e) {
+        log.error("error: {}", e.getMessage(), e);
         return ResponseEntity.status(e.getErrorCode().status())
                 .body(
                         Response.onFailure(


### PR DESCRIPTION
### 연결된 issue 🌟
- closed #43 

### 구현 내용 📢
#### 로그인 없이 접속 가능하도록 수정

로그인 없어도 접속 가능하도록 JWTAuthenticationFilter에 검증 로직을 access token 및 refresh token이 없다면 에러를 던지는 게 아닌 Filter를 넘어가도록 수정했습니다.

사용자는 총 4가지의 권한을 가지고 있습니다.
- ANONYMOUS: 익명 사용자로써, SecurityConfig에서 authenticated() 메서드를 통과하지 못합니다.
- GUEST: OAuth2를 통해 로그인 했지만 아직 회원가입(회원 프로필 등록)을 하지 않은 권한입니다.
- USER: 회원가입을 모두 완료한 유저입니다.
- ADMIN: 관리자

이를 Security Config 설정을 통해서 각 URL마다 권한을 설정할 수 있습니다!

#### 로깅 처리

실제 운영 환경에서 로그를 실시간으로 체크하기 위해 더 꼼꼼한 로깅 처리가 필요했습니다.

일단은 `CustomException`이 발생하면 log를 보여줄 수 있게 추가했습니다.