### PR TITLE
[ARV-83] 수요조사, 차대절 BoardingDate 엔티티 생성

### DIFF
--- a/src/main/java/com/backend/allreva/rent/command/domain/RentFormBoardingDate.java
+++ b/src/main/java/com/backend/allreva/rent/command/domain/RentFormBoardingDate.java
@@ -1,0 +1,35 @@
+package com.backend.allreva.rent.command.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE rent_form_boarding_date SET deleted_at = NOW() WHERE id = ?")
+public class RentFormBoardingDate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private RentForm rentForm;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Builder
+    public RentFormBoardingDate(RentForm rentForm, LocalDate date) {
+        this.rentForm = rentForm;
+        this.date = date;
+    }
+}
+

--- a/src/main/java/com/backend/allreva/rent/command/domain/value/OperationInfo.java
+++ b/src/main/java/com/backend/allreva/rent/command/domain/value/OperationInfo.java
@@ -1,9 +1,14 @@
 package com.backend.allreva.rent.command.domain.value;
 
+import com.backend.allreva.rent.command.domain.RentFormBoardingDate;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
+import jakarta.persistence.OneToMany;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Builder
@@ -14,8 +19,8 @@ public class OperationInfo {
     @Column(nullable = false)
     private String boardingArea;
 
-    @Column(nullable = false)
-    private String boardingDate;
+    @OneToMany(mappedBy = "rentForm")
+    private List<RentFormBoardingDate> boardingDates = new ArrayList<>();
 
     @Column(nullable = false)
     private String upTime;

--- a/src/main/java/com/backend/allreva/survey/command/application/SurveyBoardingDateCommandRepository.java
+++ b/src/main/java/com/backend/allreva/survey/command/application/SurveyBoardingDateCommandRepository.java
@@ -1,0 +1,22 @@
+package com.backend.allreva.survey.command.application;
+
+import com.backend.allreva.survey.command.domain.Survey;
+import com.backend.allreva.survey.command.domain.SurveyBoardingDate;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface SurveyBoardingDateCommandRepository extends JpaRepository<SurveyBoardingDate, Long> {
+
+    @Modifying
+    @Query("DELETE FROM SurveyBoardingDate sbd WHERE sbd.survey = :survey")
+    void deleteAllBySurveyForUpdate(@Param("survey") Survey survey);        // 물리삭제
+
+    void deleteAllBySurvey(Survey survey);
+
+    List<SurveyBoardingDate> findAllBySurvey(Survey survey);
+
+}

--- a/src/main/java/com/backend/allreva/survey/command/application/SurveyConverter.java
+++ b/src/main/java/com/backend/allreva/survey/command/application/SurveyConverter.java
@@ -4,6 +4,7 @@ import com.backend.allreva.common.converter.DataConverter;
 import com.backend.allreva.survey.command.application.dto.JoinSurveyRequest;
 import com.backend.allreva.survey.command.application.dto.OpenSurveyRequest;
 import com.backend.allreva.survey.command.domain.Survey;
+import com.backend.allreva.survey.command.domain.SurveyBoardingDate;
 import com.backend.allreva.survey.command.domain.SurveyJoin;
 import org.springframework.stereotype.Component;
 
@@ -15,7 +16,6 @@ public class SurveyConverter {
                 .memberId(memberId)
                 .concertId(request.concertId())
                 .title(request.title())
-                .boardingDate(request.boardingDate().stream().map(DataConverter::convertToLocalDateFromDateWithDay).toList())
                 .eddate(request.eddate())
                 .information(request.information())
                 .artistName(request.artistName())

--- a/src/main/java/com/backend/allreva/survey/command/application/dto/OpenSurveyRequest.java
+++ b/src/main/java/com/backend/allreva/survey/command/application/dto/OpenSurveyRequest.java
@@ -11,7 +11,7 @@ public record OpenSurveyRequest(
         String title,
         Long concertId,
         @NotEmpty(message = "날짜는 하루 이상 선택되어야 합니다.")
-        List<String> boardingDate, //형식은 2024.01.02(금)
+        List<String> boardingDates, //형식은 2024.01.02(금)
         String artistName,
         Region region,
         LocalDate eddate,

--- a/src/main/java/com/backend/allreva/survey/command/application/dto/UpdateSurveyRequest.java
+++ b/src/main/java/com/backend/allreva/survey/command/application/dto/UpdateSurveyRequest.java
@@ -10,7 +10,7 @@ import java.util.List;
 public record UpdateSurveyRequest(
         String title,
         @NotEmpty(message = "날짜는 하루 이상 선택되어야 합니다.")
-        List<String> boardingDate, //형식은 2024.01.02(금)
+        List<String> boardingDates, //형식은 2024.01.02(금)
         Region region,
         LocalDate eddate,
         @Min(value = 0, message = "탑승 인원 수는 0명 이상이어야 합니다.")

--- a/src/main/java/com/backend/allreva/survey/command/domain/Survey.java
+++ b/src/main/java/com/backend/allreva/survey/command/domain/Survey.java
@@ -27,12 +27,8 @@ public class Survey extends BaseEntity {
     @Column(nullable = false)
     private String title;
 
-    @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(
-            name = "survey_boarding_date",
-            joinColumns = @JoinColumn(name = "id", nullable = false)
-    )
-    private List<LocalDate> boardingDate = new ArrayList<>();
+    @OneToMany(mappedBy = "survey")
+    private List<SurveyBoardingDate> boardingDates = new ArrayList<>();
 
     @Column(nullable = false)
     private String artistName;
@@ -62,7 +58,6 @@ public class Survey extends BaseEntity {
     public Survey(final Long memberId,
                   final Long concertId,
                   final String title,
-                  final List<LocalDate> boardingDate,
                   final String artistName,
                   final Region region,
                   final LocalDate eddate,
@@ -71,7 +66,6 @@ public class Survey extends BaseEntity {
         this.memberId = memberId;
         this.concertId = concertId;
         this.title = title;
-        this.boardingDate = boardingDate;
         this.artistName = artistName;
         this.region = region;
         this.eddate = eddate;
@@ -81,13 +75,11 @@ public class Survey extends BaseEntity {
     }
 
     public void update(final String title,
-                       final List<LocalDate> boardingDate,
                        final Region region,
                        final LocalDate eddate,
                        final int maxPassenger,
                        final String information) {
         this.title = title;
-        this.boardingDate = boardingDate;
         this.region = region;
         this.eddate = eddate;
         this.maxPassenger = maxPassenger;

--- a/src/main/java/com/backend/allreva/survey/command/domain/SurveyBoardingDate.java
+++ b/src/main/java/com/backend/allreva/survey/command/domain/SurveyBoardingDate.java
@@ -1,0 +1,32 @@
+package com.backend.allreva.survey.command.domain;
+
+import com.backend.allreva.common.model.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE survey_boarding_date SET deleted_at = NOW() WHERE id = ?")
+public class SurveyBoardingDate extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Survey survey;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Builder
+    public SurveyBoardingDate(Survey survey, LocalDate date) {
+        this.survey = survey;
+        this.date = date;
+    }
+}

--- a/src/main/java/com/backend/allreva/survey/query/application/dto/SurveyDetailResponse.java
+++ b/src/main/java/com/backend/allreva/survey/query/application/dto/SurveyDetailResponse.java
@@ -11,14 +11,18 @@ import java.util.stream.Collectors;
 public final class SurveyDetailResponse {
     final Long surveyId;
     final String title;
-    final List<String> boardingDate;
+    final List<String> boardingDates;
     final String information;
     final boolean isClosed;
 
-    public SurveyDetailResponse(Long surveyId, String title, List<LocalDate> boardingDate, String information, boolean isClosed) {
+    public SurveyDetailResponse(final Long surveyId,
+                                final String title,
+                                final List<LocalDate> boardingDate,
+                                final String information,
+                                final boolean isClosed) {
         this.surveyId = surveyId;
         this.title = title;
-        this.boardingDate = boardingDate.stream()
+        this.boardingDates = boardingDate.stream()
                 .map(DataConverter::convertToDateWithDayFromLocalDate)
                 .collect(Collectors.toList());
         this.information = information;

--- a/src/main/java/com/backend/allreva/survey/query/application/dto/SurveySummaryResponse.java
+++ b/src/main/java/com/backend/allreva/survey/query/application/dto/SurveySummaryResponse.java
@@ -8,6 +8,7 @@ public record SurveySummaryResponse(
         Long surveyId,
         String title,
         Region region,
-        Long participationCount,
+        Integer participationCount,
+        Integer maxPassenger,
         LocalDate endDate) {
 }

--- a/src/test/java/com/backend/allreva/survey/query/application/SurveyQueryServiceTest.java
+++ b/src/test/java/com/backend/allreva/survey/query/application/SurveyQueryServiceTest.java
@@ -5,6 +5,7 @@ import com.backend.allreva.concert.command.domain.ConcertRepository;
 import com.backend.allreva.member.command.domain.Member;
 import com.backend.allreva.member.command.domain.MemberRepository;
 import com.backend.allreva.support.IntegrationTestSupport;
+import com.backend.allreva.survey.command.application.SurveyBoardingDateCommandRepository;
 import com.backend.allreva.survey.command.application.SurveyCommandRepository;
 import com.backend.allreva.survey.command.application.SurveyCommandService;
 import com.backend.allreva.survey.command.application.dto.OpenSurveyRequest;
@@ -39,6 +40,8 @@ public class SurveyQueryServiceTest extends IntegrationTestSupport {
     private SurveyCommandRepository surveyCommandRepository;
     @Autowired
     private ConcertRepository concertRepository;
+    @Autowired
+    private SurveyBoardingDateCommandRepository surveyBoardingDateCommandRepository;
     private Member testMember;
     private Concert testConcert;
 
@@ -53,6 +56,7 @@ public class SurveyQueryServiceTest extends IntegrationTestSupport {
     @AfterEach
     void tearDown() {
         memberRepository.deleteAllInBatch();
+        surveyBoardingDateCommandRepository.deleteAllInBatch();
         surveyCommandRepository.deleteAllInBatch();
     }
 
@@ -69,10 +73,10 @@ public class SurveyQueryServiceTest extends IntegrationTestSupport {
         // Then
         assertNotNull(detail);
         assertEquals("하현상 콘서트: Elegy [서울] 수요조사 모집합니다.", detail.getTitle());
-        assertEquals("2024.11.30(토)", detail.getBoardingDate().get(0));
-        assertEquals("2024.12.01(일)", detail.getBoardingDate().get(1));
-        assertEquals(2, detail.getBoardingDate().size());
-        assertThat(detail.getBoardingDate()).contains("2024.11.30(토)", "2024.12.01(일)");
+        assertEquals("2024.11.30(토)", detail.getBoardingDates().get(0));
+        assertEquals("2024.12.01(일)", detail.getBoardingDates().get(1));
+        assertEquals(2, detail.getBoardingDates().size());
+        assertThat(detail.getBoardingDates()).contains("2024.11.30(토)", "2024.12.01(일)");
     }
 
     @Test
@@ -90,6 +94,8 @@ public class SurveyQueryServiceTest extends IntegrationTestSupport {
         assertNotNull(responseList);
         assertFalse(responseList.isEmpty());
         assertThat(responseList).allMatch(response -> response.region().equals(Region.서울));
+        assertEquals(0, responseList.get(0).participationCount());
+        assertEquals(25, responseList.get(0).maxPassenger());
         assertEquals(firstId.surveyId(), responseList.get(0).surveyId());
     }
 
@@ -129,5 +135,4 @@ public class SurveyQueryServiceTest extends IntegrationTestSupport {
         assertEquals(secondId.surveyId(), responseList.get(1).surveyId());
         assertEquals(lastId.surveyId(), responseList.get(2).surveyId());
     }
-
 }

--- a/src/test/java/com/backend/allreva/survey/ui/SurveyControllerTest.java
+++ b/src/test/java/com/backend/allreva/survey/ui/SurveyControllerTest.java
@@ -168,7 +168,7 @@ class SurveyControllerTest extends ApiTestSupport {
     void findSurveyList() throws Exception {
         // Given
         List<SurveySummaryResponse> responseList = new ArrayList<>();
-        SurveySummaryResponse response = new SurveySummaryResponse(1L, "title", Region.경기, 20L, LocalDate.now());
+        SurveySummaryResponse response = new SurveySummaryResponse(1L, "title", Region.경기, 20, 25, LocalDate.now());
         responseList.add(response);
 
         Region region = Region.서울;


### PR DESCRIPTION
### 연결된 issue 🌟
ex) 연결된 issue를 자동으로 닫기 위해 # 다음 이슈 넘버를 입력해주세요. ex) #2 
<br>
- closed #62

### 구현 내용 📢
boardingDate 엔티티 추가했습니다.


### 테스트 결과 🧩
<img width="431" alt="스크린샷 2024-11-29 오후 8 17 43" src="https://github.com/user-attachments/assets/9c048b4b-e3ae-494c-908e-92cef2615eab">


### 리뷰 포인트 📌
네이밍이 너무 긴가요?? 의견 주세요!
