### PR TITLE
[ARV-99] token이 null로 처리되는 문제 수정

### DIFF
--- a/src/main/java/com/backend/allreva/auth/application/dto/LoginSuccessResponse.java
+++ b/src/main/java/com/backend/allreva/auth/application/dto/LoginSuccessResponse.java
@@ -3,21 +3,27 @@ package com.backend.allreva.auth.application.dto;
 import lombok.Builder;
 
 @Builder
-public record TokenResponse(
+public record LoginSuccessResponse(
         String accessToken,
         String refreshToken,
-        Long refreshTokenExpirationTime
+        Long refreshTokenExpirationTime,
+        String email,
+        String profileImageUrl
 ) {
 
-    public static TokenResponse of(
+    public static LoginSuccessResponse of(
             final String accessToken,
             final String refreshToken,
-            final Long refreshTokenExpirationTime
+            final Long refreshTokenExpirationTime,
+            final String email,
+            final String profileImageUrl
     ) {
-        return TokenResponse.builder()
+        return LoginSuccessResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .refreshTokenExpirationTime(refreshTokenExpirationTime)
+                .email(email)
+                .profileImageUrl(profileImageUrl)
                 .build();
     }
 }

--- a/src/main/java/com/backend/allreva/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/backend/allreva/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -8,7 +8,7 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.stereotype.Component;
 
 import com.backend.allreva.auth.application.dto.PrincipalDetails;
-import com.backend.allreva.auth.application.dto.TokenResponse;
+import com.backend.allreva.auth.application.dto.LoginSuccessResponse;
 import com.backend.allreva.auth.util.JwtProvider;
 import com.backend.allreva.common.dto.Response;
 import com.backend.allreva.member.command.domain.Member;
@@ -46,18 +46,22 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         String accessToken = jwtProvider.generateAccessToken(memberId);
         String refreshToken = jwtProvider.generateRefreshToken(memberId);
 
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-
         // access token 응답객체 생성
-        TokenResponse tokenResponse = TokenResponse.of(accessToken, refreshToken, jwtProvider.getREFRESH_TIME());
+        LoginSuccessResponse loginSuccessResponse = LoginSuccessResponse.of(
+                accessToken,
+                refreshToken,
+                jwtProvider.getREFRESH_TIME(),
+                member.getEmail().getEmail(),
+                member.getMemberInfo().getProfileImageUrl());
 
         // TODO: db or cache에 RefreshToken 저장
 
         // refreshToken 쿠키 등록
         setHeader(response, refreshToken);
 
-        Response<TokenResponse> apiResponse = Response.onSuccess(tokenResponse);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        Response<LoginSuccessResponse> apiResponse = Response.onSuccess(loginSuccessResponse);
         String jsonResponse = objectMapper.writeValueAsString(apiResponse);
         response.getWriter().write(jsonResponse);
     }

--- a/src/main/java/com/backend/allreva/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/backend/allreva/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -2,6 +2,7 @@ package com.backend.allreva.auth.oauth2.handler;
 
 import java.io.IOException;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -25,6 +26,8 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
+    @Value("${jwt.refresh.expiration}")
+    private Long REFRESH_TIME;
 
     /**
      * OAuth2 인증 success시 JWT 반환하는 메서드
@@ -75,10 +78,10 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     }
 
     // refreshToken 쿠키 생성
-    public static ResponseCookie createRefreshToken(final String refreshToken) {
+    public ResponseCookie createRefreshToken(final String refreshToken) {
         return ResponseCookie.from("refreshToken", refreshToken)
                 .path("/")
-                .maxAge(14 * 24 * 60 * 60 * 1000)
+                .maxAge(REFRESH_TIME)
                 .httpOnly(true)
                 .build();
     }

--- a/src/main/java/com/backend/allreva/auth/ui/DeveloperTestHandler.java
+++ b/src/main/java/com/backend/allreva/auth/ui/DeveloperTestHandler.java
@@ -6,15 +6,10 @@ import com.backend.allreva.member.command.domain.Member;
 import com.backend.allreva.member.command.domain.MemberRepository;
 import com.backend.allreva.member.command.domain.value.LoginProvider;
 import com.backend.allreva.member.command.domain.value.MemberRole;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,22 +17,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @Profile("local")
-public class DeveloperTestHandler {
+public class DeveloperTestHandler implements DeveloperTestHandlerSwagger {
 
     private final MemberRepository memberRepository;
 
-    @Operation(summary = "전지전능한 개발자 모드 생성", description = "당신은 해당 API를 호출함으로써 초사이언 개발자 모드를 얻을 수 있습니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json"))
-    })
     @GetMapping("/test-developer")
-    public ResponseEntity<Response<String>> getAdminToken() {
+    public Response<String> getAdminToken() {
         Optional<Member> optionalDeveloper = memberRepository.findMemberByMemberRole(MemberRole.DEVELOPER);
         if (optionalDeveloper.isEmpty()) {
             log.info("GOD saved");
             saveDeveloper();
         }
-        return ResponseEntity.ok(Response.onSuccess("당신은 신이 되었습니다."));
+        return Response.onSuccess("당신은 신이 되었습니다.");
     }
 
     private void saveDeveloper() {

--- a/src/main/java/com/backend/allreva/auth/ui/DeveloperTestHandlerSwagger.java
+++ b/src/main/java/com/backend/allreva/auth/ui/DeveloperTestHandlerSwagger.java
@@ -1,0 +1,19 @@
+package com.backend.allreva.auth.ui;
+
+import com.backend.allreva.common.dto.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "신이 되고 싶은가?")
+public interface DeveloperTestHandlerSwagger {
+
+    @Operation(
+            summary = "전지전능한 개발자 모드 생성",
+            description = """
+                    [다크로드](https://img.insight.co.kr/static/2020/07/29/700/drd1a625yy440q7bluvg.jpg)
+                    
+                    게발자가 되고 싶은 자 나에게로..
+                    """
+    )
+    Response<String> getAdminToken();
+}

--- a/src/main/java/com/backend/allreva/auth/ui/OAuth2Controller.java
+++ b/src/main/java/com/backend/allreva/auth/ui/OAuth2Controller.java
@@ -4,10 +4,6 @@ import com.backend.allreva.auth.application.AuthMember;
 import com.backend.allreva.member.command.application.MemberCommandFacade;
 import com.backend.allreva.member.command.application.dto.MemberInfoRequest;
 import com.backend.allreva.member.command.domain.Member;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,39 +15,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/oauth2")
-public class OAuth2Controller {
+public class OAuth2Controller implements OAuth2ControllerSwagger{
 
     private final MemberCommandFacade memberCommandFacade;
 
-    @Operation(
-            summary = "oauth2 로그인",
-            description = """
-            <b>oauth2 로그인 API</b>
-            
-            먼저 로그인을 다음 주소로 login한 후 token 주소를 얻습니다.
-            - `http://{host}:{port}/api/v1/oauth2/login/{provider}`
-            
-            이후 token을 이용하여 회원가입 절차를 진행합니다.
-            
-            두 절차를 모두 거치면 USER 권한을 가진 Member로 등록됩니다.
-            
-            ⚠️ 주의: 테스트 환경에서는 oauth2 API가 유효하지 않습니다. 로컬 테스트일 경우 /test-developer로 개발자 모드를 활성화하세요.
-            """)
-    @GetMapping("/login/provider")
+    @Override
+    @GetMapping("/login")
     public ResponseEntity<Void> login() {
-        return ResponseEntity.noContent().build();
+        return null;
     }
 
-    @Operation(summary = "oauth2 회원가입", description = "oauth2 회원가입 시 회원 정보 입력 API")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", content = @Content(mediaType = "application/json"))
-    })
+    @Override
     @PostMapping("/register")
     public ResponseEntity<Void> register(
             final @AuthMember Member member,
-            final @RequestBody MemberInfoRequest memberInfoRequest) {
+            final @RequestBody MemberInfoRequest memberInfoRequest
+    ) {
         memberCommandFacade.registerMember(memberInfoRequest, member);
-
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/backend/allreva/auth/ui/OAuth2ControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/auth/ui/OAuth2ControllerSwagger.java
@@ -1,0 +1,33 @@
+package com.backend.allreva.auth.ui;
+
+import com.backend.allreva.member.command.application.dto.MemberInfoRequest;
+import com.backend.allreva.member.command.domain.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "OAuth2 로그인 API")
+public interface OAuth2ControllerSwagger {
+    @Operation(
+            summary = "oauth2 로그인",
+            description = """
+            <b>oauth2 로그인 API</b>
+            
+            먼저 로그인을 다음 주소로 login한 후 token 주소를 얻습니다.
+            - `http://{host}:{port}/api/v1/oauth2/login/{provider}`
+            
+            이후 token을 이용하여 회원가입 절차를 진행합니다.
+            
+            두 절차를 모두 거치면 USER 권한을 가진 Member로 등록됩니다.
+            
+            ⚠️ 주의: 테스트 환경에서는 oauth2 API가 유효하지 않습니다. 로컬 테스트일 경우 /test-developer로 개발자 모드를 활성화하세요.
+            """
+    )
+    ResponseEntity<Void> login();
+
+    @Operation(
+            summary = "oauth2 회원가입",
+            description = "oauth2 회원가입 시 회원 정보 입력 API"
+    )
+    ResponseEntity<Void> register(Member member, MemberInfoRequest memberInfoRequest);
+}


### PR DESCRIPTION
### 연결된 issue 🌟
- closed #74 

### 구현 내용 📢
- refresh token null 검증 로직 추가
- 전지전능한 개발자 모드 description 변경
- oauth2 API swagger interface 분리
- oauth2 로그인 시 response로 token이외에 email, profile_url 추가


### 테스트 결과 🧩
이렇게 Body값에 주고, 쿠키로 refresh token을 등록합니다.
![image](https://github.com/user-attachments/assets/da136d67-8a76-4f56-af8e-dabb89ffa2a6)

⚠️ F12 눌러서 Application에 Cookie 속에 refresh token이 있다면 API가 동작되지 않을수도 있습니다..! 
