### PR TITLE
[ARV-120] OAuth2 로그인 리다이렉트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ out/
 
 /src/main/resources/application.yml
 /src/main/resources/application-local.yml
+/src/main/resources/application-dev.yml
 /src/main/resources/application-test.yml
 /src/test/resources/application-test.yml
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.3'
     implementation 'org.springframework.cloud:spring-cloud-commons:4.1.4'
 
-    //jaxb
+    // jaxb
     implementation 'io.github.openfeign:feign-jaxb:11.0'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.1'
@@ -72,6 +72,7 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'it.ozimov:embedded-redis:0.7.2'
 
     // aws s3
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.0'
@@ -88,9 +89,6 @@ dependencies {
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-    //kafka
-    implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/backend/allreva/artist/command/ArtistCommandService.java
+++ b/src/main/java/com/backend/allreva/artist/command/ArtistCommandService.java
@@ -1,14 +1,13 @@
 package com.backend.allreva.artist.command;
 
 import com.backend.allreva.artist.command.domain.Artist;
-import com.backend.allreva.member.command.application.dto.MemberInfoRequest;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
+import com.backend.allreva.member.command.application.dto.MemberArtistRequest;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,9 +16,9 @@ public class ArtistCommandService {
 
     private final ArtistRepository artistRepository;
 
-    public void saveIfNotExist(final List<MemberInfoRequest.MemberArtistRequest> artists) {
+    public void saveIfNotExist(final List<MemberArtistRequest> artists) {
         List<String> ids = artists.stream()
-                .map(MemberInfoRequest.MemberArtistRequest::spotifyArtistId)
+                .map(MemberArtistRequest::spotifyArtistId)
                 .toList();
 
         List<Artist> existingEntities = artistRepository
@@ -31,7 +30,7 @@ public class ArtistCommandService {
 
         List<Artist> list = artists.stream()
                 .filter(artist -> !existingIds.contains(artist.spotifyArtistId()))
-                .map(MemberInfoRequest.MemberArtistRequest::to)
+                .map(MemberArtistRequest::to)
                 .toList();
 
         artistRepository.saveAll(list);

--- a/src/main/java/com/backend/allreva/auth/domain/RefreshToken.java
+++ b/src/main/java/com/backend/allreva/auth/domain/RefreshToken.java
@@ -1,0 +1,21 @@
+package com.backend.allreva.auth.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@RedisHash(value = "refreshToken", timeToLive = 14440)
+public class RefreshToken {
+
+    @Id
+    private String token;
+    private Long memberId;
+
+    @Builder
+    private RefreshToken(final String token, final Long memberId) {
+        this.token = token;
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/com/backend/allreva/auth/domain/RefreshTokenRepository.java
+++ b/src/main/java/com/backend/allreva/auth/domain/RefreshTokenRepository.java
@@ -1,0 +1,6 @@
+package com.backend.allreva.auth.domain;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+}

--- a/src/main/java/com/backend/allreva/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/backend/allreva/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -7,7 +7,6 @@ import com.backend.allreva.auth.util.CookieUtil;
 import com.backend.allreva.auth.util.JwtProvider;
 import com.backend.allreva.member.command.domain.Member;
 import com.backend.allreva.member.command.domain.value.MemberRole;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -26,14 +25,11 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     private static final String FRONT_SIGNUP_URL = "/signup";
 
     private final JwtProvider jwtProvider;
-    private final ObjectMapper objectMapper;
     private final RefreshTokenRepository refreshTokenRepository;
     @Value("${jwt.refresh.expiration}")
     private int REFRESH_TIME;
     @Value("${jwt.access.expiration}")
     private int ACCESS_TIME;
-    @Value("${jwt.refresh.cookie-name}")
-    private String REFRESH_COOKIE_NAME;
 
     /**
      * OAuth2 인증 success시 JWT 반환하는 메서드
@@ -64,7 +60,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
         // refreshToken 쿠키 등록
         CookieUtil.addCookie(response, "accessToken", accessToken, ACCESS_TIME);
-        CookieUtil.addCookie(response, REFRESH_COOKIE_NAME, refreshToken, REFRESH_TIME);
+        CookieUtil.addCookie(response, "refreshToken", refreshToken, REFRESH_TIME);
 
         sendRedirect(response, member);
     }

--- a/src/main/java/com/backend/allreva/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/backend/allreva/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,33 +1,34 @@
 package com.backend.allreva.auth.oauth2.handler;
 
-import java.io.IOException;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseCookie;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
-import org.springframework.stereotype.Component;
-
-import com.backend.allreva.auth.application.dto.PrincipalDetails;
 import com.backend.allreva.auth.application.dto.LoginSuccessResponse;
+import com.backend.allreva.auth.application.dto.PrincipalDetails;
+import com.backend.allreva.auth.util.CookieUtil;
 import com.backend.allreva.auth.util.JwtProvider;
 import com.backend.allreva.common.dto.Response;
 import com.backend.allreva.member.command.domain.Member;
+import com.backend.allreva.member.command.domain.value.MemberRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+    private static final String FRONT_BASE_URL = "http://localhost:3000";
+    private static final String FRONT_SIGNUP_URL = "/signup";
+
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
     @Value("${jwt.refresh.expiration}")
-    private Long REFRESH_TIME;
+    private int REFRESH_TIME;
 
     /**
      * OAuth2 인증 success시 JWT 반환하는 메서드
@@ -55,34 +56,32 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
                 refreshToken,
                 jwtProvider.getREFRESH_TIME(),
                 member.getEmail().getEmail(),
-                member.getMemberInfo().getProfileImageUrl());
+                member.getMemberInfo().getProfileImageUrl()
+        );
 
         // TODO: db or cache에 RefreshToken 저장
 
         // refreshToken 쿠키 등록
-        setHeader(response, refreshToken);
+        CookieUtil.addCookie(response, "refreshToken", refreshToken, REFRESH_TIME);
 
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-        Response<LoginSuccessResponse> apiResponse = Response.onSuccess(loginSuccessResponse);
-        String jsonResponse = objectMapper.writeValueAsString(apiResponse);
-        response.getWriter().write(jsonResponse);
-    }
-
-    // refreshToken 쿠키 설정
-    public void setHeader(final HttpServletResponse response, final String refreshToken) {
-        if (refreshToken != null) {
-            response.addHeader("refresh_token", refreshToken);
-            response.addHeader("Set-Cookie", createRefreshToken(refreshToken).toString());
+        setResponseBody(response, loginSuccessResponse);
+        if (member.getMemberRole().equals(MemberRole.USER)) {
+            response.sendRedirect(FRONT_BASE_URL);
+        } else {
+            response.sendRedirect(FRONT_BASE_URL + FRONT_SIGNUP_URL);
         }
     }
 
-    // refreshToken 쿠키 생성
-    public ResponseCookie createRefreshToken(final String refreshToken) {
-        return ResponseCookie.from("refreshToken", refreshToken)
-                .path("/")
-                .maxAge(REFRESH_TIME)
-                .httpOnly(true)
-                .build();
+    private void setResponseBody(
+            final HttpServletResponse response,
+            final LoginSuccessResponse loginSuccessResponse
+    ) throws IOException {
+        Response<LoginSuccessResponse> apiResponse = Response.onSuccess(loginSuccessResponse);
+        String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(jsonResponse);
     }
 }

--- a/src/main/java/com/backend/allreva/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/backend/allreva/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -6,6 +6,7 @@ import com.backend.allreva.auth.domain.RefreshTokenRepository;
 import com.backend.allreva.auth.util.CookieUtil;
 import com.backend.allreva.auth.util.JwtProvider;
 import com.backend.allreva.member.command.domain.Member;
+import com.backend.allreva.member.command.domain.value.MemberRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -65,17 +66,17 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         CookieUtil.addCookie(response, "accessToken", accessToken, ACCESS_TIME);
         CookieUtil.addCookie(response, REFRESH_COOKIE_NAME, refreshToken, REFRESH_TIME);
 
-        //sendRedirect(response, member);
+        sendRedirect(response, member);
     }
 
     private void sendRedirect(
             final HttpServletResponse response,
             final Member member
     ) throws IOException {
-        /*if (member.getMemberRole().equals(MemberRole.USER)) {
+        if (member.getMemberRole().equals(MemberRole.USER)) {
             response.sendRedirect(FRONT_BASE_URL);
         } else {
             response.sendRedirect(FRONT_BASE_URL + FRONT_SIGNUP_URL);
-        }*/
+        }
     }
 }

--- a/src/main/java/com/backend/allreva/auth/ui/OAuth2Controller.java
+++ b/src/main/java/com/backend/allreva/auth/ui/OAuth2Controller.java
@@ -5,12 +5,14 @@ import com.backend.allreva.member.command.application.MemberCommandFacade;
 import com.backend.allreva.member.command.application.dto.MemberInfoRequest;
 import com.backend.allreva.member.command.domain.Member;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,19 +21,21 @@ public class OAuth2Controller implements OAuth2ControllerSwagger{
 
     private final MemberCommandFacade memberCommandFacade;
 
-    @Override
     @GetMapping("/login")
     public ResponseEntity<Void> login() {
         return null;
     }
 
-    @Override
-    @PostMapping("/register")
-    public ResponseEntity<Void> register(
-            final @AuthMember Member member,
-            final @RequestBody MemberInfoRequest memberInfoRequest
+    /**
+     * oauth2 회원가입
+     */
+    @PostMapping(path = "/register", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Void> registerMember(
+            @AuthMember final Member member,
+            @RequestPart final MemberInfoRequest memberInfoRequest,
+            @RequestPart(value = "image", required = false) final MultipartFile image
     ) {
-        memberCommandFacade.registerMember(memberInfoRequest, member);
+        memberCommandFacade.registerMember(memberInfoRequest, member, image);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/backend/allreva/auth/ui/OAuth2ControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/auth/ui/OAuth2ControllerSwagger.java
@@ -22,7 +22,7 @@ public interface OAuth2ControllerSwagger {
             <b>oauth2 로그인 API</b>
             
             먼저 로그인을 다음 주소로 login한 후 token 주소를 얻습니다.
-            - `http://{host}:{port}/api/v1/oauth2/login/{provider}`
+            - ex) `/api/v1/oauth2/login/kakao`
             
             이후 token을 이용하여 회원가입 절차를 진행합니다.
             

--- a/src/main/java/com/backend/allreva/auth/ui/OAuth2ControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/auth/ui/OAuth2ControllerSwagger.java
@@ -1,13 +1,21 @@
 package com.backend.allreva.auth.ui;
 
+import com.backend.allreva.auth.application.AuthMember;
 import com.backend.allreva.member.command.application.dto.MemberInfoRequest;
 import com.backend.allreva.member.command.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "OAuth2 로그인 API")
 public interface OAuth2ControllerSwagger {
+
     @Operation(
             summary = "oauth2 로그인",
             description = """
@@ -25,9 +33,14 @@ public interface OAuth2ControllerSwagger {
     )
     ResponseEntity<Void> login();
 
-    @Operation(
-            summary = "oauth2 회원가입",
-            description = "oauth2 회원가입 시 회원 정보 입력 API"
-    )
-    ResponseEntity<Void> register(Member member, MemberInfoRequest memberInfoRequest);
+    @Operation(summary = "oauth2 회원가입", description = "oauth2 회원가입 시 USER 권한으로 승격됩니다.")
+    @RequestBody(
+            content = @Content(
+                    encoding = @Encoding(
+                            name = "memberInfoRequest", contentType = MediaType.APPLICATION_JSON_VALUE)))
+    ResponseEntity<Void> registerMember(
+            @AuthMember Member member,
+            @RequestPart MemberInfoRequest memberInfoRequest,
+            @RequestPart(value = "image", required = false) MultipartFile image
+    );
 }

--- a/src/main/java/com/backend/allreva/auth/util/CookieUtil.java
+++ b/src/main/java/com/backend/allreva/auth/util/CookieUtil.java
@@ -1,0 +1,30 @@
+package com.backend.allreva.auth.util;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CookieUtil {
+
+    private static final String COOKIE_DOMAIN = "localhost:3000";
+
+    // refreshToken 쿠키 생성
+    public static void addCookie(
+            final HttpServletResponse response,
+            final String name,
+            final String value,
+            final int maxAge
+    ) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .domain(COOKIE_DOMAIN)
+                .path("/")
+                .maxAge(maxAge)
+                .httpOnly(true)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+}

--- a/src/main/java/com/backend/allreva/auth/util/CookieUtil.java
+++ b/src/main/java/com/backend/allreva/auth/util/CookieUtil.java
@@ -19,7 +19,7 @@ public final class CookieUtil {
             final int maxAge
     ) {
         ResponseCookie cookie = ResponseCookie.from(name, value)
-                .domain(COOKIE_DOMAIN)
+                //.domain(COOKIE_DOMAIN)
                 .path("/")
                 .maxAge(maxAge)
                 .httpOnly(true)

--- a/src/main/java/com/backend/allreva/common/config/RedisEmbeddedConfig.java
+++ b/src/main/java/com/backend/allreva/common/config/RedisEmbeddedConfig.java
@@ -1,0 +1,48 @@
+package com.backend.allreva.common.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import redis.embedded.RedisServer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisEmbeddedConfig {
+
+    private final RedisServer redisServer;
+
+    public RedisEmbeddedConfig(
+            @Value("${spring.data.redis.port}") final int port,
+            @Value("${spring.data.redis.host}") final String host
+    ) {
+        this.redisServer = new RedisServer(port);
+    }
+
+    @PostConstruct
+    public void startRedis() {
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        redisServer.stop();
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<byte[], byte[]> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        return template;
+    }
+}

--- a/src/main/java/com/backend/allreva/common/config/SecurityConfig.java
+++ b/src/main/java/com/backend/allreva/common/config/SecurityConfig.java
@@ -61,6 +61,12 @@ public class SecurityConfig {
                         .requestMatchers(ALLOW_URLS).permitAll()
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/v1/oauth2/**").hasRole("GUEST")
+                        .requestMatchers("/api/v1/search/**").permitAll()
+                        .requestMatchers("/api/v1/concerts/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/surveys/list").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/surveys").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/rents/list").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/rents").permitAll()
                         .anyRequest().authenticated())
                 .httpBasic(AbstractHttpConfigurer::disable);
 

--- a/src/main/java/com/backend/allreva/member/command/application/MemberArtistCommandService.java
+++ b/src/main/java/com/backend/allreva/member/command/application/MemberArtistCommandService.java
@@ -2,15 +2,14 @@ package com.backend.allreva.member.command.application;
 
 import com.backend.allreva.artist.command.ArtistCommandService;
 import com.backend.allreva.artist.query.application.ArtistQueryService;
-import com.backend.allreva.member.command.application.dto.MemberInfoRequest.MemberArtistRequest;
+import com.backend.allreva.member.command.application.dto.MemberArtistRequest;
 import com.backend.allreva.member.command.domain.Member;
 import com.backend.allreva.member.command.domain.MemberArtist;
 import com.backend.allreva.member.command.domain.MemberArtistRepository;
 import com.backend.allreva.member.command.domain.MemberArtistService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/backend/allreva/member/command/application/MemberCommandFacade.java
+++ b/src/main/java/com/backend/allreva/member/command/application/MemberCommandFacade.java
@@ -1,11 +1,14 @@
 package com.backend.allreva.member.command.application;
 
+import com.backend.allreva.common.application.S3ImageService;
+import com.backend.allreva.common.model.Image;
 import com.backend.allreva.member.command.application.dto.MemberInfoRequest;
 import com.backend.allreva.member.command.application.dto.RefundAccountRequest;
 import com.backend.allreva.member.command.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @Service
@@ -14,23 +17,27 @@ public class MemberCommandFacade {
 
     private final MemberInfoCommandService memberInfoCommandService;
     private final MemberArtistCommandService memberArtistCommandService;
+    private final S3ImageService s3ImageService;
 
     @Transactional
     public void registerMember(
             final MemberInfoRequest memberInfoRequest,
-            final Member member
+            final Member member,
+            final MultipartFile image
     ) {
-        // TODO: 이미지 S3 등록 및 URL 응답
-        memberInfoCommandService.registerMember(memberInfoRequest, member);
+        Image uploadedImage = s3ImageService.upload(image);
+        memberInfoCommandService.registerMember(memberInfoRequest, member, uploadedImage);
         memberArtistCommandService.updateMemberArtist(memberInfoRequest.memberArtistRequests(), member);
     }
 
     @Transactional
     public void updateMemberInfo(
             final MemberInfoRequest memberInfoRequest,
-            final Member member
+            final Member member,
+            final MultipartFile image
     ) {
-        memberInfoCommandService.updateMemberInfo(memberInfoRequest, member);
+        Image uploadedImage = s3ImageService.upload(image);
+        memberInfoCommandService.updateMemberInfo(memberInfoRequest, member, uploadedImage);
         memberArtistCommandService.updateMemberArtist(memberInfoRequest.memberArtistRequests(), member);
     }
 

--- a/src/main/java/com/backend/allreva/member/command/application/MemberInfoCommandService.java
+++ b/src/main/java/com/backend/allreva/member/command/application/MemberInfoCommandService.java
@@ -1,5 +1,6 @@
 package com.backend.allreva.member.command.application;
 
+import com.backend.allreva.common.model.Image;
 import com.backend.allreva.member.command.application.dto.MemberInfoRequest;
 import com.backend.allreva.member.command.application.dto.RefundAccountRequest;
 import com.backend.allreva.member.command.domain.Member;
@@ -18,14 +19,15 @@ public class MemberInfoCommandService {
      */
     public Member registerMember(
             final MemberInfoRequest memberInfoRequest,
-            final Member member
+            final Member member,
+            final Image image
     ) {
         member.setMemberInfo(
                 memberInfoRequest.nickname(),
                 memberInfoRequest.introduce(),
-                memberInfoRequest.profileImageUrl()
+                image.getUrl()
         );
-        member.upgradeToUser();
+        member.upgradeToUser(); // USER 권한으로 변경
         return memberRepository.save(member);
     }
 
@@ -34,12 +36,13 @@ public class MemberInfoCommandService {
      */
     public Member updateMemberInfo(
             final MemberInfoRequest memberInfoRequest,
-            final Member member
+            final Member member,
+            final Image image
     ) {
         member.setMemberInfo(
                 memberInfoRequest.nickname(),
                 memberInfoRequest.introduce(),
-                memberInfoRequest.profileImageUrl()
+                image.getUrl()
         );
         return memberRepository.save(member);
     }

--- a/src/main/java/com/backend/allreva/member/command/application/dto/MemberArtistRequest.java
+++ b/src/main/java/com/backend/allreva/member/command/application/dto/MemberArtistRequest.java
@@ -1,0 +1,12 @@
+package com.backend.allreva.member.command.application.dto;
+
+import com.backend.allreva.artist.command.domain.Artist;
+
+public record MemberArtistRequest(
+        String spotifyArtistId,
+        String name
+) {
+    public static Artist to(final MemberArtistRequest memberArtistRequest) {
+        return new Artist(memberArtistRequest.spotifyArtistId(), memberArtistRequest.name());
+    }
+}

--- a/src/main/java/com/backend/allreva/member/command/application/dto/MemberInfoRequest.java
+++ b/src/main/java/com/backend/allreva/member/command/application/dto/MemberInfoRequest.java
@@ -1,22 +1,11 @@
 package com.backend.allreva.member.command.application.dto;
 
-import com.backend.allreva.artist.command.domain.Artist;
-
 import java.util.List;
 
 public record MemberInfoRequest(
         String nickname,
         String introduce,
-        String profileImageUrl,
         List<MemberArtistRequest> memberArtistRequests
 ) {
 
-    public record MemberArtistRequest(
-            String spotifyArtistId,
-            String name
-    ) {
-        public static Artist to(final MemberArtistRequest memberArtistRequest) {
-            return new Artist(memberArtistRequest.spotifyArtistId(), memberArtistRequest.name());
-        }
-    }
 }

--- a/src/main/java/com/backend/allreva/member/command/domain/MemberArtistService.java
+++ b/src/main/java/com/backend/allreva/member/command/domain/MemberArtistService.java
@@ -1,6 +1,6 @@
 package com.backend.allreva.member.command.domain;
 
-import com.backend.allreva.member.command.application.dto.MemberInfoRequest.MemberArtistRequest;
+import com.backend.allreva.member.command.application.dto.MemberArtistRequest;
 import java.util.List;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/backend/allreva/member/ui/MemberController.java
+++ b/src/main/java/com/backend/allreva/member/ui/MemberController.java
@@ -7,46 +7,63 @@ import com.backend.allreva.member.command.application.dto.MemberInfoRequest;
 import com.backend.allreva.member.command.application.dto.RefundAccountRequest;
 import com.backend.allreva.member.command.domain.Member;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/members")
-public class MemberController {
+public class MemberController implements MemberControllerSwagger {
 
     private final MemberCommandFacade memberCommandFacade;
 
-    @PatchMapping("/info")
-    public Response<Void> updateMemberInfo(
-            final @AuthMember Member member,
-            final @RequestBody MemberInfoRequest memberInfoRequest
+    /**
+     * oauth2 회원가입
+     *
+     * OAuth2 기본 이미지
+     */
+    @PostMapping(path = "/register", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Void> registerMember(
+            @AuthMember final Member member,
+            @RequestPart final MemberInfoRequest memberInfoRequest,
+            @RequestPart(value = "image", required = false) final MultipartFile image
     ) {
-        memberCommandFacade.updateMemberInfo(memberInfoRequest, member);
+        memberCommandFacade.registerMember(memberInfoRequest, member, image);
+        return ResponseEntity.noContent().build();
+    }
 
+    @PatchMapping(path = "/info", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public Response<Void> updateMemberInfo(
+            @AuthMember final Member member,
+            @RequestPart final MemberInfoRequest memberInfoRequest,
+            @RequestPart(value = "image", required = false) final MultipartFile image
+    ) {
+        memberCommandFacade.updateMemberInfo(memberInfoRequest, member, image);
         return Response.onSuccess();
     }
 
     @PostMapping("/refund-account")
     public Response<Void> registerRefundAccount(
-            final @AuthMember Member member,
-            final @RequestBody RefundAccountRequest refundAccountRequest
+            @AuthMember final Member member,
+            @RequestBody final RefundAccountRequest refundAccountRequest
     ) {
         memberCommandFacade.registerRefundAccount(refundAccountRequest, member);
-
         return Response.onSuccess();
     }
 
     @DeleteMapping("/refund-account")
     public Response<Void> deleteRefundAccount(
-            final @AuthMember Member member
+            @AuthMember final Member member
     ) {
         memberCommandFacade.deleteRefundAccount(member);
-
         return Response.onSuccess();
     }
 }

--- a/src/main/java/com/backend/allreva/member/ui/MemberController.java
+++ b/src/main/java/com/backend/allreva/member/ui/MemberController.java
@@ -6,14 +6,13 @@ import com.backend.allreva.member.command.application.MemberCommandFacade;
 import com.backend.allreva.member.command.application.dto.MemberInfoRequest;
 import com.backend.allreva.member.command.application.dto.RefundAccountRequest;
 import com.backend.allreva.member.command.domain.Member;
-import com.backend.allreva.member.query.application.MemberQueryService;
-import com.backend.allreva.member.query.application.dto.MemberDetail;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,17 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberCommandFacade memberCommandFacade;
-    private final MemberQueryService memberQueryService;
 
-    @Operation(summary = "회원 프로필 조회", description = "회원 프로필 조회 API")
-    @GetMapping
-    public Response<MemberDetail> getMemberDetail(
-            final @AuthMember Member member
-    ) {
-        return Response.onSuccess(memberQueryService.getById(member.getId()));
-    }
-
-    @Operation(summary = "회원 프로필 수정", description = "회원 프로필 수정 API")
     @PatchMapping("/info")
     public Response<Void> updateMemberInfo(
             final @AuthMember Member member,
@@ -42,7 +31,6 @@ public class MemberController {
         return Response.onSuccess();
     }
 
-    @Operation(summary = "회원 환불 계좌 등록", description = "회원 환불 계좌 등록 API")
     @PostMapping("/refund-account")
     public Response<Void> registerRefundAccount(
             final @AuthMember Member member,
@@ -53,7 +41,6 @@ public class MemberController {
         return Response.onSuccess();
     }
 
-    @Operation(summary = "회원 환불 계좌 삭제", description = "회원 환불 계좌 삭제 API")
     @DeleteMapping("/refund-account")
     public Response<Void> deleteRefundAccount(
             final @AuthMember Member member

--- a/src/main/java/com/backend/allreva/member/ui/MemberController.java
+++ b/src/main/java/com/backend/allreva/member/ui/MemberController.java
@@ -8,7 +8,6 @@ import com.backend.allreva.member.command.application.dto.RefundAccountRequest;
 import com.backend.allreva.member.command.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,13 +30,13 @@ public class MemberController implements MemberControllerSwagger {
      * OAuth2 기본 이미지
      */
     @PostMapping(path = "/register", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Void> registerMember(
+    public Response<Void> registerMember(
             @AuthMember final Member member,
             @RequestPart final MemberInfoRequest memberInfoRequest,
             @RequestPart(value = "image", required = false) final MultipartFile image
     ) {
         memberCommandFacade.registerMember(memberInfoRequest, member, image);
-        return ResponseEntity.noContent().build();
+        return Response.onSuccess();
     }
 
     @PatchMapping(path = "/info", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/backend/allreva/member/ui/MemberControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/member/ui/MemberControllerSwagger.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -23,7 +22,7 @@ public interface MemberControllerSwagger {
             content = @Content(
                 encoding = @Encoding(
                         name = "memberInfoRequest", contentType = MediaType.APPLICATION_JSON_VALUE)))
-    ResponseEntity<Void> registerMember(
+    Response<Void> registerMember(
             @AuthMember Member member,
             @RequestPart MemberInfoRequest memberInfoRequest,
             @RequestPart(value = "image", required = false) MultipartFile image

--- a/src/main/java/com/backend/allreva/member/ui/MemberControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/member/ui/MemberControllerSwagger.java
@@ -6,16 +6,38 @@ import com.backend.allreva.member.command.application.dto.MemberInfoRequest;
 import com.backend.allreva.member.command.application.dto.RefundAccountRequest;
 import com.backend.allreva.member.command.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "회원 API", description = "회원 정보를 관리하는 API")
 public interface MemberControllerSwagger {
 
-    @Operation(summary = "회원 프로필 수정", description = "회원 프로필 수정 API")
+    @Operation(summary = "oauth2 회원가입", description = "oauth2 회원가입 시 USER 권한으로 승격됩니다.")
+    @RequestBody(
+            content = @Content(
+                encoding = @Encoding(
+                        name = "memberInfoRequest", contentType = MediaType.APPLICATION_JSON_VALUE)))
+    ResponseEntity<Void> registerMember(
+            @AuthMember Member member,
+            @RequestPart MemberInfoRequest memberInfoRequest,
+            @RequestPart(value = "image", required = false) MultipartFile image
+    );
+
+    @Operation(summary = "회원 프로필 수정", description = "회원 프로필 수정 API, USER 권한일 때만 사용 가능합니다.")
+    @RequestBody(
+            content = @Content(
+                    encoding = @Encoding(
+                            name = "memberInfoRequest", contentType = MediaType.APPLICATION_JSON_VALUE)))
     Response<Void> updateMemberInfo(
             @AuthMember Member member,
-            @RequestBody MemberInfoRequest memberInfoRequest
+            @RequestPart MemberInfoRequest memberInfoRequest,
+            @RequestPart(value = "image", required = false) MultipartFile image
     );
 
     @Operation(summary = "회원 환불 계좌 등록", description = "회원 환불 계좌 등록 API")

--- a/src/main/java/com/backend/allreva/member/ui/MemberControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/member/ui/MemberControllerSwagger.java
@@ -1,0 +1,31 @@
+package com.backend.allreva.member.ui;
+
+import com.backend.allreva.auth.application.AuthMember;
+import com.backend.allreva.common.dto.Response;
+import com.backend.allreva.member.command.application.dto.MemberInfoRequest;
+import com.backend.allreva.member.command.application.dto.RefundAccountRequest;
+import com.backend.allreva.member.command.domain.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "회원 API", description = "회원 정보를 관리하는 API")
+public interface MemberControllerSwagger {
+
+    @Operation(summary = "회원 프로필 수정", description = "회원 프로필 수정 API")
+    Response<Void> updateMemberInfo(
+            @AuthMember Member member,
+            @RequestBody MemberInfoRequest memberInfoRequest
+    );
+
+    @Operation(summary = "회원 환불 계좌 등록", description = "회원 환불 계좌 등록 API")
+    Response<Void> registerRefundAccount(
+            @AuthMember Member member,
+            @RequestBody RefundAccountRequest refundAccountRequest
+    );
+
+    @Operation(summary = "회원 환불 계좌 삭제", description = "회원 환불 계좌 삭제 API")
+    Response<Void> deleteRefundAccount(
+            @AuthMember Member member
+    );
+}

--- a/src/main/java/com/backend/allreva/member/ui/MemberViewController.java
+++ b/src/main/java/com/backend/allreva/member/ui/MemberViewController.java
@@ -1,0 +1,28 @@
+package com.backend.allreva.member.ui;
+
+import com.backend.allreva.auth.application.AuthMember;
+import com.backend.allreva.common.dto.Response;
+import com.backend.allreva.member.command.domain.Member;
+import com.backend.allreva.member.query.application.MemberQueryService;
+import com.backend.allreva.member.query.application.dto.MemberDetail;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/members")
+public class MemberViewController implements MemberViewControllerSwagger {
+
+    private final MemberQueryService memberQueryService;
+
+    @Operation(summary = "회원 프로필 조회", description = "회원 프로필 조회 API")
+    @GetMapping
+    public Response<MemberDetail> getMemberDetail(
+            final @AuthMember Member member
+    ) {
+        return Response.onSuccess(memberQueryService.getById(member.getId()));
+    }
+}

--- a/src/main/java/com/backend/allreva/member/ui/MemberViewControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/member/ui/MemberViewControllerSwagger.java
@@ -1,0 +1,20 @@
+package com.backend.allreva.member.ui;
+
+import com.backend.allreva.auth.application.AuthMember;
+import com.backend.allreva.common.dto.Response;
+import com.backend.allreva.member.command.domain.Member;
+import com.backend.allreva.member.query.application.dto.MemberDetail;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "회원 정보 조회 API", description = "회원 정보 조회 API")
+public interface MemberViewControllerSwagger {
+
+    @Operation(
+            summary = "회원 정보 조회",
+            description = "회원 정보를 조회합니다."
+    )
+    Response<MemberDetail> getMemberDetail(
+            @AuthMember Member member
+    );
+}

--- a/src/test/java/com/backend/allreva/artist/command/ArtistCommandServiceTest.java
+++ b/src/test/java/com/backend/allreva/artist/command/ArtistCommandServiceTest.java
@@ -1,17 +1,16 @@
 package com.backend.allreva.artist.command;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.backend.allreva.artist.command.domain.Artist;
 import com.backend.allreva.artist.query.application.ArtistQueryService;
 import com.backend.allreva.artist.query.application.dto.SpotifySearchResponse;
-import com.backend.allreva.member.command.application.dto.MemberInfoRequest.MemberArtistRequest;
+import com.backend.allreva.member.command.application.dto.MemberArtistRequest;
 import com.backend.allreva.support.IntegrationTestSupport;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class ArtistCommandServiceTest extends IntegrationTestSupport {
     @Autowired

--- a/src/test/java/com/backend/allreva/member/command/MemberArtistCommandTest.java
+++ b/src/test/java/com/backend/allreva/member/command/MemberArtistCommandTest.java
@@ -1,14 +1,20 @@
 package com.backend.allreva.member.command;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import com.backend.allreva.artist.command.ArtistCommandService;
 import com.backend.allreva.artist.command.domain.Artist;
 import com.backend.allreva.artist.query.application.ArtistQueryService;
 import com.backend.allreva.member.command.application.MemberArtistCommandService;
-import com.backend.allreva.member.command.application.dto.MemberInfoRequest.MemberArtistRequest;
+import com.backend.allreva.member.command.application.dto.MemberArtistRequest;
 import com.backend.allreva.member.command.domain.Member;
 import com.backend.allreva.member.command.domain.MemberArtistRepository;
 import com.backend.allreva.member.command.domain.MemberArtistService;
 import com.backend.allreva.member.command.domain.value.LoginProvider;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,16 +23,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("NonAsciiCharacters")
-public class MemberArtistCommandTest {
+class MemberArtistCommandTest {
 
     @Mock
     private MemberArtistRepository memberArtistRepository;

--- a/src/test/java/com/backend/allreva/member/command/MemberInfoCommandTest.java
+++ b/src/test/java/com/backend/allreva/member/command/MemberInfoCommandTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import com.backend.allreva.common.application.S3ImageService;
+import com.backend.allreva.common.model.Image;
 import com.backend.allreva.member.command.application.MemberInfoCommandService;
 import com.backend.allreva.member.command.application.dto.MemberInfoRequest;
 import com.backend.allreva.member.command.domain.Member;
@@ -22,13 +24,14 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("NonAsciiCharacters")
-public class MemberInfoCommandTest {
+class MemberInfoCommandTest {
 
     @InjectMocks
     private MemberInfoCommandService memberInfoCommandService;
-
     @Mock
     private MemberRepository memberRepository;
+    @Mock
+    private S3ImageService s3ImageService;
 
     Member member;
 
@@ -45,16 +48,16 @@ public class MemberInfoCommandTest {
     @Test
     void 회원_가입_시_회원_정보를_성공적으로_등록한다() {
         // given
+        var uploadedImage = new Image("https://my_picture");
         var memberInfoRequest = new MemberInfoRequest(
                 "updated nickname",
                 "test introduce",
-                "updated profile image url",
                 List.of()
         );
         given(memberRepository.save(any(Member.class))).willReturn(member);
 
         // when
-        var updatedMember = memberInfoCommandService.registerMember(memberInfoRequest, member);
+        var updatedMember = memberInfoCommandService.registerMember(memberInfoRequest, member, uploadedImage);
 
         // then
         assertSoftly(softly -> {
@@ -66,16 +69,16 @@ public class MemberInfoCommandTest {
     @Test
     void 회원_정보를_성공적으로_수정한다() {
         // given
+        var uploadedImage = new Image("https://my_picture");
         var memberInfoRequest = new MemberInfoRequest(
                 "updated nickname",
                 "test introduce",
-                "updated profile image url",
                 List.of()
         );
         given(memberRepository.save(any(Member.class))).willReturn(member);
 
         // when
-        Member updatedMember = memberInfoCommandService.updateMemberInfo(memberInfoRequest, member);
+        Member updatedMember = memberInfoCommandService.updateMemberInfo(memberInfoRequest, member, uploadedImage);
 
         // then
         assertThat(updatedMember.getMemberInfo().getIntroduce()).isEqualTo("test introduce");

--- a/src/test/java/com/backend/allreva/member/ui/OAuth2RegisterUITest.java
+++ b/src/test/java/com/backend/allreva/member/ui/OAuth2RegisterUITest.java
@@ -1,22 +1,25 @@
 package com.backend.allreva.member.ui;
 
-import com.backend.allreva.member.command.application.dto.MemberInfoRequest;
-import com.backend.allreva.member.command.application.dto.MemberInfoRequest.MemberArtistRequest;
-import com.backend.allreva.member.command.domain.Member;
-import com.backend.allreva.support.ApiTestSupport;
-import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
-
-import java.util.List;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.backend.allreva.member.command.application.dto.MemberArtistRequest;
+import com.backend.allreva.member.command.application.dto.MemberInfoRequest;
+import com.backend.allreva.member.command.domain.Member;
+import com.backend.allreva.support.ApiTestSupport;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockPart;
+import org.springframework.web.multipart.MultipartFile;
+
 @SuppressWarnings("NonAsciiCharacters")
-public class OAuth2RegisterUITest extends ApiTestSupport {
+class OAuth2RegisterUITest extends ApiTestSupport {
 
     @Test
     void oauth2_회원가입_API() throws Exception {
@@ -28,15 +31,16 @@ public class OAuth2RegisterUITest extends ApiTestSupport {
         var memberInfoRequest = new MemberInfoRequest(
                 "updated nickname",
                 "test introduce",
-                "updated profile image url",
                 memberArtistRequests
         );
-        willDoNothing().given(memberCommandFacade).registerMember(any(MemberInfoRequest.class), any(Member.class));
+        var uploadedImage = new MockMultipartFile("image", "test.jpg", "image/jpeg", "test".getBytes());
+        willDoNothing().given(memberCommandFacade).registerMember(any(MemberInfoRequest.class), any(Member.class), any(MultipartFile.class));
 
         // when
-        var resultActions = mockMvc.perform(post("/api/v1/oauth2/register")
-                .content(objectMapper.writeValueAsString(memberInfoRequest))
-                .contentType(MediaType.APPLICATION_JSON)
+        var resultActions = mockMvc.perform(multipart(HttpMethod.POST, "/api/v1/oauth2/register")
+                .file(uploadedImage)
+                .part(new MockPart("memberInfoRequest", "application/json", objectMapper.writeValueAsBytes(memberInfoRequest)))
+                .contentType(MediaType.MULTIPART_FORM_DATA)
         );
 
         // then


### PR DESCRIPTION
### 연결된 issue 🌟
- closed #99 

### 구현 내용 📢
#### redirect 추가

OAuth2 로그인 시 자동으로 이동할 수 있도록 redirect를 적용하였습니다.
- GUEST: 회원가입 창으로 이동
- USER이상: 메인 페이지 이동

💡 현재는 임시로 `localhost:3000` 도메인을 사용했습니다.

#### refresh, access token cookie 추가

본래 refresh만 쿠키에 두고 JSON으로 응답값을 보냈는데, redirect가 적용됨으로써 body에 전송이 되지 않아 cookie에 두 토큰 정보를 모두 추가하였습니다.

#### 이미지 등록 추가

프로필 수정 시(회원가입 포함) 이미지를 S3에 저장할 수 있도록 구현했습니다.

💡 Swagger에도 Multipart 데이터를 입력할 수 있도록 적용했습니다.
![image](https://github.com/user-attachments/assets/43724798-5975-4bb7-896e-3e0c69837d3a)

#### main, concert, rent permitAll 추가

### 테스트 결과 🧩

