### PR TITLE
[ARV-126] 차 대절 이벤트 발행 로직 구현

### DIFF
--- a/src/main/java/com/backend/allreva/common/config/KafkaConfig.java
+++ b/src/main/java/com/backend/allreva/common/config/KafkaConfig.java
@@ -13,9 +13,16 @@ import org.springframework.kafka.config.TopicBuilder;
 public class KafkaConfig {
 
     public static final String TOPIC_CONCERT_VIEW = "concertLike-event";
+
     public static final String TOPIC_SURVEY_SAVE = "survey-save";
     public static final String TOPIC_SURVEY_DELETE = "survey-delete";
     public static final String TOPIC_SURVEY_JOIN = "survey-join";
+
+    public static final String TOPIC_RENT_SAVE = "rent-save";
+    public static final String TOPIC_RENT_DELETE = "rent-delete";
+
+    public static final String TOPIC_RENT_JOIN_SAVE = "rent-join-delete";
+    public static final String TOPIC_RENT_JOIN_DELETE = "rent-join-delete";
 
     // 토픽 설정
     @Bean
@@ -44,6 +51,13 @@ public class KafkaConfig {
     @Bean
     public NewTopic surveyDeleteTopic() {
         return TopicBuilder.name(TOPIC_SURVEY_DELETE)
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+    @Bean
+    public NewTopic surveyJoinTopic() {
+        return TopicBuilder.name(TOPIC_SURVEY_JOIN)
                 .partitions(1)
                 .replicas(1)
                 .build();

--- a/src/main/java/com/backend/allreva/common/config/KafkaConfig.java
+++ b/src/main/java/com/backend/allreva/common/config/KafkaConfig.java
@@ -1,5 +1,12 @@
 package com.backend.allreva.common.config;
 
+import static com.backend.allreva.concert.command.domain.ViewAddedEvent.TOPIC_CONCERT_VIEW;
+import static com.backend.allreva.rent.command.domain.RentDeleteEvent.TOPIC_RENT_DELETE;
+import static com.backend.allreva.rent.command.domain.RentSaveEvent.TOPIC_RENT_SAVE;
+import static com.backend.allreva.survey.command.domain.SurveyDeletedEvent.TOPIC_SURVEY_DELETE;
+import static com.backend.allreva.survey.command.domain.SurveyJoinEvent.TOPIC_SURVEY_JOIN;
+import static com.backend.allreva.survey.command.domain.SurveySavedEvent.TOPIC_SURVEY_SAVE;
+
 import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -12,18 +19,6 @@ import org.springframework.kafka.config.TopicBuilder;
 @ConfigurationProperties(prefix = "kafka")
 public class KafkaConfig {
 
-    public static final String TOPIC_CONCERT_VIEW = "concertLike-event";
-
-    public static final String TOPIC_SURVEY_SAVE = "survey-save";
-    public static final String TOPIC_SURVEY_DELETE = "survey-delete";
-    public static final String TOPIC_SURVEY_JOIN = "survey-join";
-
-    public static final String TOPIC_RENT_SAVE = "rent-save";
-    public static final String TOPIC_RENT_DELETE = "rent-delete";
-
-    public static final String TOPIC_RENT_JOIN_SAVE = "rent-join-delete";
-    public static final String TOPIC_RENT_JOIN_DELETE = "rent-join-delete";
-
     // 토픽 설정
     @Bean
     public NewTopic concertLikeTopic() {
@@ -34,15 +29,24 @@ public class KafkaConfig {
     }
 
     @Bean
-    public NewTopic rentTopic() {
-        return TopicBuilder.name("rent-event")
+    public NewTopic rentSaveTopic() {
+        return TopicBuilder.name(TOPIC_RENT_SAVE)
                 .partitions(1)
                 .replicas(1)
                 .build();
     }
 
     @Bean
-    public NewTopic surveyCreateTopic() {
+    public NewTopic rentDeleteTopic() {
+        return TopicBuilder.name(TOPIC_RENT_DELETE)
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+
+
+    @Bean
+    public NewTopic surveySaveTopic() {
         return TopicBuilder.name(TOPIC_SURVEY_SAVE)
                 .partitions(1)
                 .replicas(1)

--- a/src/main/java/com/backend/allreva/concert/command/domain/Concert.java
+++ b/src/main/java/com/backend/allreva/concert/command/domain/Concert.java
@@ -97,10 +97,6 @@ public class Concert extends BaseEntity {
 
     public void addViewCount(final int count) {
         this.viewCount += count;
-        Events.raise(
-                ViewAddedEvent.builder()
-                        .concertCode(this.code.getConcertCode())
-                        .viewCount(this.viewCount)
-                        .build());
+        Events.raise(new ViewAddedEvent(this));
     }
 }

--- a/src/main/java/com/backend/allreva/concert/command/domain/ViewAddedEvent.java
+++ b/src/main/java/com/backend/allreva/concert/command/domain/ViewAddedEvent.java
@@ -1,16 +1,15 @@
 package com.backend.allreva.concert.command.domain;
 
 import com.backend.allreva.common.event.Event;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static com.backend.allreva.common.config.KafkaConfig.TOPIC_CONCERT_VIEW;
-
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ViewAddedEvent extends Event {
 
-    private final String topic = TOPIC_CONCERT_VIEW;
+    public static final String TOPIC_CONCERT_VIEW = "concertView-event";
     private String concertCode;
     private long viewCount;
 

--- a/src/main/java/com/backend/allreva/concert/command/domain/ViewAddedEvent.java
+++ b/src/main/java/com/backend/allreva/concert/command/domain/ViewAddedEvent.java
@@ -1,25 +1,22 @@
 package com.backend.allreva.concert.command.domain;
 
 import com.backend.allreva.common.event.Event;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.backend.allreva.common.config.KafkaConfig.TOPIC_CONCERT_VIEW;
 
 @Getter
+@NoArgsConstructor
 public class ViewAddedEvent extends Event {
 
-    private final String topic;
-    private final String concertCode;
-    private final long viewCount;
+    private final String topic = TOPIC_CONCERT_VIEW;
+    private String concertCode;
+    private long viewCount;
 
-    @Builder
-    private ViewAddedEvent(
-            @JsonProperty("concertCode") final String concertCode,
-            @JsonProperty("viewCount") final long viewCount
-    ) {
-        this.topic = "concertLike-event";
-        this.concertCode = concertCode;
-        this.viewCount = viewCount;
+    public ViewAddedEvent(final Concert concert) {
+        this.concertCode = concert.getCode().getConcertCode();
+        this.viewCount = concert.getViewCount();
     }
 
 }

--- a/src/main/java/com/backend/allreva/concert/infra/ConcertInternalEventHandler.java
+++ b/src/main/java/com/backend/allreva/concert/infra/ConcertInternalEventHandler.java
@@ -1,5 +1,7 @@
 package com.backend.allreva.concert.infra;
 
+import static com.backend.allreva.concert.command.domain.ViewAddedEvent.TOPIC_CONCERT_VIEW;
+
 import com.backend.allreva.common.event.EventEntry;
 import com.backend.allreva.common.event.EventRepository;
 import com.backend.allreva.common.event.JsonParsingError;
@@ -24,7 +26,7 @@ public class ConcertInternalEventHandler {
     public void onMessage(ViewAddedEvent event) {
         String payload = serializeEvent(event);
         EventEntry eventEntry = EventEntry.builder()
-                .topic(event.getTopic())
+                .topic(TOPIC_CONCERT_VIEW)
                 .payload(payload)
                 .build();
 

--- a/src/main/java/com/backend/allreva/rent/command/application/RentCommandService.java
+++ b/src/main/java/com/backend/allreva/rent/command/application/RentCommandService.java
@@ -1,15 +1,13 @@
 package com.backend.allreva.rent.command.application;
 
+import com.backend.allreva.common.event.Events;
 import com.backend.allreva.rent.command.application.dto.RentIdRequest;
 import com.backend.allreva.rent.command.application.dto.RentJoinApplyRequest;
 import com.backend.allreva.rent.command.application.dto.RentJoinIdRequest;
 import com.backend.allreva.rent.command.application.dto.RentJoinUpdateRequest;
 import com.backend.allreva.rent.command.application.dto.RentRegisterRequest;
 import com.backend.allreva.rent.command.application.dto.RentUpdateRequest;
-import com.backend.allreva.rent.command.domain.Rent;
-import com.backend.allreva.rent.command.domain.RentJoin;
-import com.backend.allreva.rent.command.domain.RentJoinRepository;
-import com.backend.allreva.rent.command.domain.RentRepository;
+import com.backend.allreva.rent.command.domain.*;
 import com.backend.allreva.rent.exception.RentJoinNotFoundException;
 import com.backend.allreva.rent.exception.RentNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +28,7 @@ public class RentCommandService {
     ) {
         Rent rent = rentRegisterRequest.toEntity(memberId);
         Rent savedRent = rentRepository.save(rent);
+        Events.raise(new RentSaveEvent(savedRent));
         return savedRent.getId();
     }
 

--- a/src/main/java/com/backend/allreva/rent/command/domain/Rent.java
+++ b/src/main/java/com/backend/allreva/rent/command/domain/Rent.java
@@ -1,32 +1,18 @@
 package com.backend.allreva.rent.command.domain;
 
+import com.backend.allreva.common.event.Events;
 import com.backend.allreva.common.model.BaseEntity;
 import com.backend.allreva.common.model.Image;
 import com.backend.allreva.rent.command.application.dto.RentUpdateRequest;
-import com.backend.allreva.rent.command.domain.value.AdditionalInfo;
-import com.backend.allreva.rent.command.domain.value.Bus;
-import com.backend.allreva.rent.command.domain.value.DetailInfo;
-import com.backend.allreva.rent.command.domain.value.OperationInfo;
-import com.backend.allreva.rent.command.domain.value.Price;
+import com.backend.allreva.rent.command.domain.value.*;
 import com.backend.allreva.rent.exception.RentAccessDeniedException;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Builder
@@ -107,6 +93,8 @@ public class Rent extends BaseEntity {
                 .toList();
         assignBoardingDates(rentBoardingDates);
         isClosed = false;
+
+        Events.raise(new RentSaveEvent(this));
     }
 
     public void validateMine(Long memberId) {
@@ -117,5 +105,6 @@ public class Rent extends BaseEntity {
 
     public void close() {
         isClosed = true;
+        Events.raise(new RentDeleteEvent(id));
     }
 }

--- a/src/main/java/com/backend/allreva/rent/command/domain/RentDeleteEvent.java
+++ b/src/main/java/com/backend/allreva/rent/command/domain/RentDeleteEvent.java
@@ -1,0 +1,21 @@
+package com.backend.allreva.rent.command.domain;
+
+import com.backend.allreva.common.event.Event;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import static com.backend.allreva.common.config.KafkaConfig.TOPIC_RENT_DELETE;
+
+@Getter
+public class RentDeleteEvent extends Event {
+
+    private final String topic = TOPIC_RENT_DELETE;
+
+    private final Long rentId;
+
+    public RentDeleteEvent(
+            @JsonProperty("rentId") final Long rentId
+    ) {
+        this.rentId = rentId;
+    }
+}

--- a/src/main/java/com/backend/allreva/rent/command/domain/RentDeleteEvent.java
+++ b/src/main/java/com/backend/allreva/rent/command/domain/RentDeleteEvent.java
@@ -1,20 +1,20 @@
 package com.backend.allreva.rent.command.domain;
 
 import com.backend.allreva.common.event.Event;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
 import lombok.Getter;
-
-import static com.backend.allreva.common.config.KafkaConfig.TOPIC_RENT_DELETE;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RentDeleteEvent extends Event {
 
-    private final String topic = TOPIC_RENT_DELETE;
+    public static final String TOPIC_RENT_DELETE = "rent-delete";
 
-    private final Long rentId;
+    private Long rentId;
 
     public RentDeleteEvent(
-            @JsonProperty("rentId") final Long rentId
+            final Long rentId
     ) {
         this.rentId = rentId;
     }

--- a/src/main/java/com/backend/allreva/rent/command/domain/RentSaveEvent.java
+++ b/src/main/java/com/backend/allreva/rent/command/domain/RentSaveEvent.java
@@ -3,18 +3,17 @@ package com.backend.allreva.rent.command.domain;
 import com.backend.allreva.common.event.Event;
 import com.backend.allreva.common.model.Image;
 import com.backend.allreva.rent.query.application.domain.RentDocument;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-import static com.backend.allreva.common.config.KafkaConfig.TOPIC_RENT_SAVE;
-
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RentSaveEvent extends Event {
 
-    private final String topic = TOPIC_RENT_SAVE;
+    public static final String TOPIC_RENT_SAVE = "rent-save";
 
     private Long rentId;
     private String title;
@@ -29,21 +28,6 @@ public class RentSaveEvent extends Event {
         this.image = rent.getDetailInfo().getImage();
         this.endDate = rent.getAdditionalInfo().getEndDate();
     }
-
-    /*@Builder
-    private RentSaveEvent(
-            @JsonProperty("rentId") final Long rentId,
-            @JsonProperty("title") final String title,
-            @JsonProperty("boardingArea") final String boardingArea,
-            @JsonProperty("imageUrl") final Image image,
-            @JsonProperty("endDate") final LocalDate endDate
-    ) {
-        this.rentId = rentId;
-        this.title = title;
-        this.boardingArea = boardingArea;
-        this.image = image;
-        this.endDate = endDate;
-    }*/
 
     public RentDocument to() {
         return RentDocument.builder()

--- a/src/main/java/com/backend/allreva/rent/command/domain/RentSaveEvent.java
+++ b/src/main/java/com/backend/allreva/rent/command/domain/RentSaveEvent.java
@@ -1,0 +1,57 @@
+package com.backend.allreva.rent.command.domain;
+
+import com.backend.allreva.common.event.Event;
+import com.backend.allreva.common.model.Image;
+import com.backend.allreva.rent.query.application.domain.RentDocument;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+import static com.backend.allreva.common.config.KafkaConfig.TOPIC_RENT_SAVE;
+
+@Getter
+@NoArgsConstructor
+public class RentSaveEvent extends Event {
+
+    private final String topic = TOPIC_RENT_SAVE;
+
+    private Long rentId;
+    private String title;
+    private String boardingArea;
+    private Image image;
+    private LocalDate endDate;
+
+    public RentSaveEvent(final Rent rent) {
+        this.rentId = rent.getId();
+        this.title = rent.getDetailInfo().getTitle();
+        this.boardingArea = rent.getOperationInfo().getBoardingArea();
+        this.image = rent.getDetailInfo().getImage();
+        this.endDate = rent.getAdditionalInfo().getEndDate();
+    }
+
+    /*@Builder
+    private RentSaveEvent(
+            @JsonProperty("rentId") final Long rentId,
+            @JsonProperty("title") final String title,
+            @JsonProperty("boardingArea") final String boardingArea,
+            @JsonProperty("imageUrl") final Image image,
+            @JsonProperty("endDate") final LocalDate endDate
+    ) {
+        this.rentId = rentId;
+        this.title = title;
+        this.boardingArea = boardingArea;
+        this.image = image;
+        this.endDate = endDate;
+    }*/
+
+    public RentDocument to() {
+        return RentDocument.builder()
+                .id(rentId.toString())
+                .title(title)
+                .boardingArea(boardingArea)
+                .imageUrl(image.getUrl())
+                .edDate(endDate)
+                .build();
+    }
+}

--- a/src/main/java/com/backend/allreva/rent/infra/RentInternalEventHandler.java
+++ b/src/main/java/com/backend/allreva/rent/infra/RentInternalEventHandler.java
@@ -1,0 +1,56 @@
+package com.backend.allreva.rent.infra;
+
+
+import com.backend.allreva.common.event.Event;
+import com.backend.allreva.common.event.EventEntry;
+import com.backend.allreva.common.event.EventRepository;
+import com.backend.allreva.common.event.JsonParsingError;
+import com.backend.allreva.rent.command.domain.RentDeleteEvent;
+import com.backend.allreva.rent.command.domain.RentSaveEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RentInternalEventHandler {
+
+    private final EventRepository eventRepository;
+    private final ObjectMapper objectMapper;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void onMessage(final RentSaveEvent event) {
+        String payload = serializeEvent(event);
+        EventEntry eventEntry = EventEntry.builder()
+                .topic(event.getTopic())
+                .payload(payload)
+                .build();
+
+        eventRepository.save(eventEntry);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void onMessage(final RentDeleteEvent event) {
+        String payload = serializeEvent(event);
+        EventEntry eventEntry = EventEntry.builder()
+                .topic(event.getTopic())
+                .payload(payload)
+                .build();
+
+        eventRepository.save(eventEntry);
+    }
+
+    private String serializeEvent(Event event) {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage());
+            throw new JsonParsingError();
+        }
+    }
+}

--- a/src/main/java/com/backend/allreva/rent/infra/RentInternalEventHandler.java
+++ b/src/main/java/com/backend/allreva/rent/infra/RentInternalEventHandler.java
@@ -1,6 +1,9 @@
 package com.backend.allreva.rent.infra;
 
 
+import static com.backend.allreva.rent.command.domain.RentDeleteEvent.TOPIC_RENT_DELETE;
+import static com.backend.allreva.rent.command.domain.RentSaveEvent.TOPIC_RENT_SAVE;
+
 import com.backend.allreva.common.event.Event;
 import com.backend.allreva.common.event.EventEntry;
 import com.backend.allreva.common.event.EventRepository;
@@ -27,7 +30,7 @@ public class RentInternalEventHandler {
     public void onMessage(final RentSaveEvent event) {
         String payload = serializeEvent(event);
         EventEntry eventEntry = EventEntry.builder()
-                .topic(event.getTopic())
+                .topic(TOPIC_RENT_SAVE)
                 .payload(payload)
                 .build();
 
@@ -38,7 +41,7 @@ public class RentInternalEventHandler {
     public void onMessage(final RentDeleteEvent event) {
         String payload = serializeEvent(event);
         EventEntry eventEntry = EventEntry.builder()
-                .topic(event.getTopic())
+                .topic(TOPIC_RENT_DELETE)
                 .payload(payload)
                 .build();
 

--- a/src/main/java/com/backend/allreva/rent/infra/RentListener.java
+++ b/src/main/java/com/backend/allreva/rent/infra/RentListener.java
@@ -1,0 +1,70 @@
+package com.backend.allreva.rent.infra;
+
+import com.backend.allreva.common.event.JsonParsingError;
+import com.backend.allreva.rent.command.domain.RentDeleteEvent;
+import com.backend.allreva.rent.command.domain.RentSaveEvent;
+import com.backend.allreva.rent.query.application.domain.RentDocument;
+import com.backend.allreva.rent.query.application.domain.RentDocumentRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.backend.allreva.common.config.KafkaConfig.TOPIC_RENT_DELETE;
+import static com.backend.allreva.common.config.KafkaConfig.TOPIC_RENT_SAVE;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RentListener {
+
+    private final RentDocumentRepository rentDocumentRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    @KafkaListener(
+            topics = TOPIC_RENT_SAVE,
+            groupId = "${spring.kafka.consumer.group-id}",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void handleSaveEvent(final String message) {
+        RentSaveEvent event = deserializeSavedEvent(message);
+        RentDocument rentDocument = event.to();
+        rentDocumentRepository.save(rentDocument);
+        log.info("차 대절 es 저장 성공: {}", rentDocument.getId());
+    }
+
+    @Transactional
+    @KafkaListener(
+            topics = TOPIC_RENT_DELETE,
+            groupId = "${spring.kafka.consumer.group-id}",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void handleDeleteEvent(final String message) {
+        RentDeleteEvent event = deserializeDeleteEvent(message);
+        Long rentId = event.getRentId();
+        rentDocumentRepository.deleteById(rentId.toString());
+        log.info("차 대절 삭제 성공: {}", rentId);
+    }
+
+
+    private RentSaveEvent deserializeSavedEvent(final String message) {
+        try {
+            return objectMapper.readValue(message, RentSaveEvent.class);
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage());
+            throw new JsonParsingError();
+        }
+    }
+    private RentDeleteEvent deserializeDeleteEvent(final String message) {
+        try {
+            return objectMapper.readValue(message, RentDeleteEvent.class);
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage());
+            throw new JsonParsingError();
+        }
+    }
+}

--- a/src/main/java/com/backend/allreva/rent/infra/RentListener.java
+++ b/src/main/java/com/backend/allreva/rent/infra/RentListener.java
@@ -13,8 +13,8 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.backend.allreva.common.config.KafkaConfig.TOPIC_RENT_DELETE;
-import static com.backend.allreva.common.config.KafkaConfig.TOPIC_RENT_SAVE;
+import static com.backend.allreva.rent.command.domain.RentDeleteEvent.TOPIC_RENT_DELETE;
+import static com.backend.allreva.rent.command.domain.RentSaveEvent.TOPIC_RENT_SAVE;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/com/backend/allreva/survey/command/application/SurveyCommandService.java
+++ b/src/main/java/com/backend/allreva/survey/command/application/SurveyCommandService.java
@@ -43,14 +43,7 @@ public class SurveyCommandService {
         Survey survey = surveyCommandRepository.save(surveyConverter.toSurvey(memberId, request));
         saveBoardingDates(survey, request.boardingDates());
 
-        Events.raise(
-                SurveySavedEvent.builder()
-                        .surveyId(survey.getId())
-                        .title(survey.getTitle())
-                        .region(survey.getRegion())
-                        .endDate(survey.getEndDate())
-                        .build()
-        );
+        Events.raise(new SurveySavedEvent(survey));
         return survey.getId();
     }
 

--- a/src/main/java/com/backend/allreva/survey/command/domain/Survey.java
+++ b/src/main/java/com/backend/allreva/survey/command/domain/Survey.java
@@ -86,14 +86,7 @@ public class Survey extends BaseEntity {
         this.maxPassenger = maxPassenger;
         this.information = information;
 
-        Events.raise(
-                SurveySavedEvent.builder()
-                        .surveyId(id)
-                        .title(title)
-                        .endDate(endDate)
-                        .region(region)
-                        .build()
-        );
+        Events.raise(new SurveySavedEvent(this));
     }
 
     public boolean isWriter(final Long loginMemberId) {

--- a/src/main/java/com/backend/allreva/survey/command/domain/SurveyDeletedEvent.java
+++ b/src/main/java/com/backend/allreva/survey/command/domain/SurveyDeletedEvent.java
@@ -1,19 +1,19 @@
 package com.backend.allreva.survey.command.domain;
 
 import com.backend.allreva.common.event.Event;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
 import lombok.Getter;
-
-import static com.backend.allreva.common.config.KafkaConfig.TOPIC_SURVEY_DELETE;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SurveyDeletedEvent extends Event {
-    private final String topic = TOPIC_SURVEY_DELETE;
+    public static final String TOPIC_SURVEY_DELETE = "survey-delete";
 
-    private final Long surveyId;
+    private Long surveyId;
 
     public SurveyDeletedEvent(
-            @JsonProperty("surveyId") final Long surveyId
+            final Long surveyId
     ) {
         this.surveyId = surveyId;
     }

--- a/src/main/java/com/backend/allreva/survey/command/domain/SurveyJoinEvent.java
+++ b/src/main/java/com/backend/allreva/survey/command/domain/SurveyJoinEvent.java
@@ -1,22 +1,22 @@
 package com.backend.allreva.survey.command.domain;
 
 import com.backend.allreva.common.event.Event;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
 import lombok.Getter;
-
-import static com.backend.allreva.common.config.KafkaConfig.TOPIC_SURVEY_JOIN;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SurveyJoinEvent extends Event {
 
-    private final String topic = TOPIC_SURVEY_JOIN;
+    public static final String TOPIC_SURVEY_JOIN = "survey-join";
 
-    private final Long surveyId;
-    private final int participationCount;
+    private Long surveyId;
+    private int participationCount;
 
     public SurveyJoinEvent(
-            @JsonProperty("surveyId") Long surveyId,
-            @JsonProperty("participationCount") int participationCount
+            final Long surveyId,
+            final int participationCount
     ) {
         this.surveyId = surveyId;
         this.participationCount = participationCount;

--- a/src/main/java/com/backend/allreva/survey/command/domain/SurveySavedEvent.java
+++ b/src/main/java/com/backend/allreva/survey/command/domain/SurveySavedEvent.java
@@ -3,18 +3,17 @@ package com.backend.allreva.survey.command.domain;
 import com.backend.allreva.common.event.Event;
 import com.backend.allreva.survey.command.domain.value.Region;
 import com.backend.allreva.survey.query.application.domain.SurveyDocument;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-import static com.backend.allreva.common.config.KafkaConfig.TOPIC_SURVEY_SAVE;
-
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SurveySavedEvent extends Event {
 
-    private final String topic = TOPIC_SURVEY_SAVE;
+    public static final String TOPIC_SURVEY_SAVE = "survey-save";
 
     private Long surveyId;
     private String title;

--- a/src/main/java/com/backend/allreva/survey/command/domain/SurveySavedEvent.java
+++ b/src/main/java/com/backend/allreva/survey/command/domain/SurveySavedEvent.java
@@ -3,36 +3,29 @@ package com.backend.allreva.survey.command.domain;
 import com.backend.allreva.common.event.Event;
 import com.backend.allreva.survey.command.domain.value.Region;
 import com.backend.allreva.survey.query.application.domain.SurveyDocument;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 import static com.backend.allreva.common.config.KafkaConfig.TOPIC_SURVEY_SAVE;
 
 @Getter
+@NoArgsConstructor
 public class SurveySavedEvent extends Event {
 
     private final String topic = TOPIC_SURVEY_SAVE;
 
-    private final Long surveyId;
-    private final String title;
-    private final Region region;
-    private final LocalDate endDate;
+    private Long surveyId;
+    private String title;
+    private Region region;
+    private LocalDate endDate;
 
-
-    @Builder
-    private SurveySavedEvent(
-            @JsonProperty("surveyId") final Long surveyId,
-            @JsonProperty("title") final String title,
-            @JsonProperty("region") final Region region,
-            @JsonProperty("endDate") final LocalDate endDate
-    ) {
-        this.surveyId = surveyId;
-        this.title = title;
-        this.region = region;
-        this.endDate = endDate;
+    public SurveySavedEvent(final Survey survey) {
+        this.surveyId = survey.getId();
+        this.title = survey.getTitle();
+        this.region = survey.getRegion();
+        this.endDate = survey.getEndDate();
     }
 
     public SurveyDocument to() {

--- a/src/main/java/com/backend/allreva/survey/infra/SurveyInternalEventHandler.java
+++ b/src/main/java/com/backend/allreva/survey/infra/SurveyInternalEventHandler.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Slf4j
 @RequiredArgsConstructor
 @Service
-public class SurveyInternalHandler {
+public class SurveyInternalEventHandler {
 
     private final EventRepository eventRepository;
     private final ObjectMapper objectMapper;
@@ -33,7 +33,6 @@ public class SurveyInternalHandler {
                 .build();
 
         eventRepository.save(eventEntry);
-        log.info("savedEvent outbox 저장 성공");
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)

--- a/src/main/java/com/backend/allreva/survey/infra/SurveyInternalEventHandler.java
+++ b/src/main/java/com/backend/allreva/survey/infra/SurveyInternalEventHandler.java
@@ -1,6 +1,10 @@
 package com.backend.allreva.survey.infra;
 
 
+import static com.backend.allreva.survey.command.domain.SurveyDeletedEvent.TOPIC_SURVEY_DELETE;
+import static com.backend.allreva.survey.command.domain.SurveyJoinEvent.TOPIC_SURVEY_JOIN;
+import static com.backend.allreva.survey.command.domain.SurveySavedEvent.TOPIC_SURVEY_SAVE;
+
 import com.backend.allreva.common.event.Event;
 import com.backend.allreva.common.event.EventEntry;
 import com.backend.allreva.common.event.EventRepository;
@@ -28,7 +32,7 @@ public class SurveyInternalEventHandler {
     public void onMessage(final SurveySavedEvent event) {
         String payload = serializeEvent(event);
         EventEntry eventEntry = EventEntry.builder()
-                .topic(event.getTopic())
+                .topic(TOPIC_SURVEY_SAVE)
                 .payload(payload)
                 .build();
 
@@ -39,7 +43,7 @@ public class SurveyInternalEventHandler {
     public void onMessage(final SurveyDeletedEvent event) {
         String payload = serializeEvent(event);
         EventEntry eventEntry = EventEntry.builder()
-                .topic(event.getTopic())
+                .topic(TOPIC_SURVEY_DELETE)
                 .payload(payload)
                 .build();
 
@@ -50,7 +54,7 @@ public class SurveyInternalEventHandler {
     public void onMessage(final SurveyJoinEvent event) {
         String payload = serializeEvent(event);
         EventEntry eventEntry = EventEntry.builder()
-                .topic(event.getTopic())
+                .topic(TOPIC_SURVEY_JOIN)
                 .payload(payload)
                 .build();
 

--- a/src/main/java/com/backend/allreva/survey/infra/SurveyListener.java
+++ b/src/main/java/com/backend/allreva/survey/infra/SurveyListener.java
@@ -16,6 +16,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.backend.allreva.common.config.KafkaConfig.*;
+import static com.backend.allreva.survey.command.domain.SurveyDeletedEvent.TOPIC_SURVEY_DELETE;
+import static com.backend.allreva.survey.command.domain.SurveyJoinEvent.TOPIC_SURVEY_JOIN;
+import static com.backend.allreva.survey.command.domain.SurveySavedEvent.TOPIC_SURVEY_SAVE;
 
 @Slf4j
 @RequiredArgsConstructor


### PR DESCRIPTION
### 연결된 issue 🌟
ex) 연결된 issue를 자동으로 닫기 위해 # 다음 이슈 넘버를 입력해주세요. ex) #2 
<br>
- closed #104 

### 구현 내용 📢
차대절 생성, 삭제 시 이벤트 발행하여 es 와 연동

### 테스트 결과 🧩
![image](https://github.com/user-attachments/assets/3c7bf986-d703-40f2-a24e-d187452d2abb)



### 리뷰 포인트 📌
Rent domain 에 RentSavedEvent, RentDeleteEvent, Rent 메서드에 들어가있는 각종 이벤트 발행 로직 
infra 에 RentInternalEventHandler, RentListener
